### PR TITLE
feat: add unique variable names rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo add graphql-tools
 - [x] NoUnusedFragments
 - [x] PossibleFragmentSpreads
 - [x] NoFragmentCycles
-- [ ] UniqueVariableNames
+- [x] UniqueVariableNames
 - [x] NoUndefinedVariables
 - [x] NoUnusedVariables
 - [ ] KnownDirectives

--- a/src/validation/rules/defaults.rs
+++ b/src/validation/rules/defaults.rs
@@ -3,9 +3,10 @@ use crate::validation::validate::ValidationPlan;
 use super::{
     FieldsOnCorrectType, FragmentsOnCompositeTypes, KnownArgumentNames, KnownFragmentNames,
     KnownTypeNames, LeafFieldSelections, LoneAnonymousOperation, NoFragmentsCycle,
-    NoUndefinedVariables, NoUnusedFragments, OverlappingFieldsCanBeMerged, PossibleFragmentSpreads,
-    ProvidedRequiredArguments, SingleFieldSubscriptions, UniqueArgumentNames, UniqueFragmentNames,
-    UniqueOperationNames, VariablesAreInputTypes, NoUnusedVariables,
+    NoUndefinedVariables, NoUnusedFragments, NoUnusedVariables, OverlappingFieldsCanBeMerged,
+    PossibleFragmentSpreads, ProvidedRequiredArguments, SingleFieldSubscriptions,
+    UniqueArgumentNames, UniqueFragmentNames, UniqueOperationNames, UniqueVariableNames,
+    VariablesAreInputTypes,
 };
 
 pub fn default_rules_validation_plan() -> ValidationPlan {
@@ -29,6 +30,7 @@ pub fn default_rules_validation_plan() -> ValidationPlan {
     plan.add_rule(Box::new(NoUndefinedVariables {}));
     plan.add_rule(Box::new(KnownArgumentNames {}));
     plan.add_rule(Box::new(UniqueArgumentNames {}));
+    plan.add_rule(Box::new(UniqueVariableNames {}));
     plan.add_rule(Box::new(ProvidedRequiredArguments {}));
 
     plan

--- a/src/validation/rules/mod.rs
+++ b/src/validation/rules/mod.rs
@@ -19,6 +19,7 @@ pub mod single_field_subscriptions;
 pub mod unique_argument_names;
 pub mod unique_fragment_names;
 pub mod unique_operation_names;
+pub mod unique_variable_names;
 pub mod variables_are_input_types;
 
 pub use self::defaults::*;
@@ -41,4 +42,5 @@ pub use self::single_field_subscriptions::*;
 pub use self::unique_argument_names::*;
 pub use self::unique_fragment_names::*;
 pub use self::unique_operation_names::*;
+pub use self::unique_variable_names::*;
 pub use self::variables_are_input_types::*;

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use super::ValidationRule;
 use crate::static_graphql::query::*;
@@ -35,16 +35,16 @@ impl<'a> QueryVisitor<UniqueVariableNamesHelper<'a>> for UniqueVariableNames {
     ) {
         let variables = node.get_variables();
 
-        let mut seen_variables = HashMap::new();
+        let mut seen_variables: HashSet<String> = HashSet::new();
 
         variables.iter().for_each(|var| {
-            if seen_variables.contains_key(&var.name) {
+            if seen_variables.contains(&var.name) {
                 visitor_context.error_context.report_error(ValidationError {
                     locations: vec![],
                     message: format!("There can only be one variable named \"${}\".", var.name),
                 });
             } else {
-                seen_variables.insert(var.name.clone(), true);
+                seen_variables.insert(var.name.clone());
             }
         })
     }

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+
+use super::ValidationRule;
+use crate::static_graphql::query::*;
+use crate::validation::utils::{ValidationError, ValidationErrorContext};
+use crate::{
+    ast::{ext::AstWithVariables, QueryVisitor},
+    validation::utils::ValidationContext,
+};
+
+/// Unique variable names
+///
+/// A GraphQL operation is only valid if all its variables are uniquely named.
+///
+/// See https://spec.graphql.org/draft/#sec-Variable-Uniqueness
+pub struct UniqueVariableNames;
+
+struct UniqueVariableNamesHelper<'a> {
+    error_context: ValidationErrorContext<'a>,
+}
+
+impl<'a> UniqueVariableNamesHelper<'a> {
+    fn new(validation_context: &'a ValidationContext<'a>) -> Self {
+        UniqueVariableNamesHelper {
+            error_context: ValidationErrorContext::new(validation_context),
+        }
+    }
+}
+
+impl<'a> QueryVisitor<UniqueVariableNamesHelper<'a>> for UniqueVariableNames {
+    fn leave_operation_definition(
+        &self,
+        node: &OperationDefinition,
+        visitor_context: &mut UniqueVariableNamesHelper<'a>,
+    ) {
+        let variables = node.get_variables();
+
+        let mut seen_variables = HashMap::new();
+
+        variables.iter().for_each(|var| {
+            if seen_variables.contains_key(&var.name) {
+                visitor_context.error_context.report_error(ValidationError {
+                    locations: vec![],
+                    message: format!("There can only be one variable named \"${}\".", var.name),
+                });
+            } else {
+                seen_variables.insert(var.name.clone(), true);
+            }
+        })
+    }
+}
+
+impl ValidationRule for UniqueVariableNames {
+    fn validate<'a>(&self, ctx: &ValidationContext) -> Vec<ValidationError> {
+        let mut helper = UniqueVariableNamesHelper::new(&ctx);
+        self.visit_document(&ctx.operation.clone(), &mut helper);
+
+        helper.error_context.errors
+    }
+}
+
+#[test]
+fn unique_variable_names() {
+    use crate::validation::test_utils::*;
+
+    let mut plan = create_plan_from_rule(Box::new(UniqueVariableNames {}));
+    let errors = test_operation_without_schema(
+        "query A($x: Int, $y: String) { __typename }
+        query B($x: String, $y: Int) { __typename }",
+        &mut plan,
+    );
+
+    assert_eq!(get_messages(&errors).len(), 0);
+}
+
+#[test]
+fn duplicate_variable_names() {
+    use crate::validation::test_utils::*;
+
+    let mut plan = create_plan_from_rule(Box::new(UniqueVariableNames {}));
+    let errors = test_operation_without_schema(
+        "query A($x: Int, $x: Int, $x: String) { __typename }
+        query B($y: String, $y: Int) { __typename }
+        query C($z: Int, $z: Int) { __typename }",
+        &mut plan,
+    );
+
+    let messages = get_messages(&errors);
+
+    assert_eq!(messages.len(), 4);
+    assert!(messages.contains(&&"There can only be one variable named \"$x\".".to_owned()));
+    assert!(messages.contains(&&"There can only be one variable named \"$y\".".to_owned()));
+    assert!(messages.contains(&&"There can only be one variable named \"$z\".".to_owned()));
+}


### PR DESCRIPTION
add rule to ensure variable names are unique. See https://spec.graphql.org/draft/#sec-Variable-Uniqueness

Closes #9 