### PR TITLE
Add Clone macro to ValidationError

### DIFF
--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -16,7 +16,7 @@ impl ValidationErrorContext {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidationError {
     pub locations: Vec<Pos>,
     pub message: String,


### PR DESCRIPTION
I want to clone `Vec<ValidationError>`.