### PR TITLE
Remove a lot of cloning from ast::ext::SchemaDocumentExtension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ name = "graphql-tools"
 version = "0.1.0"
 dependencies = [
  "graphql-parser",
+ "lazy_static",
  "serde",
  "serde_json",
 ]
@@ -57,6 +58,12 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Dotan Simha <dotansimha@gmail.com>"]
 
 [dependencies]
 graphql-parser = "^0.4.0"
+lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src/ast/collect_fields.rs
+++ b/src/ast/collect_fields.rs
@@ -9,7 +9,7 @@ use crate::static_graphql::{
 pub fn collect_fields<'a>(
     selection_set: &query::SelectionSet,
     parent_type: &schema::TypeDefinition,
-    known_fragments: &HashMap<String, query::FragmentDefinition>,
+    known_fragments: &HashMap<&str, &query::FragmentDefinition>,
     context: &'a OperationVisitorContext<'a>,
 ) -> HashMap<String, Vec<query::Field>> {
     let mut map = HashMap::new();
@@ -63,7 +63,7 @@ fn does_fragment_condition_match<'a>(
 fn collect_fields_inner<'a>(
     selection_set: &query::SelectionSet,
     parent_type: &schema::TypeDefinition,
-    known_fragments: &HashMap<String, query::FragmentDefinition>,
+    known_fragments: &HashMap<&str, &query::FragmentDefinition>,
     context: &'a OperationVisitorContext<'a>,
     result_arr: &mut HashMap<String, Vec<query::Field>>,
     visited_fragments_names: &mut Vec<String>,
@@ -93,7 +93,7 @@ fn collect_fields_inner<'a>(
             {
                 visited_fragments_names.push(f.fragment_name.clone());
 
-                if let Some(fragment) = known_fragments.get(&f.fragment_name) {
+                if let Some(fragment) = known_fragments.get(f.fragment_name.as_str()) {
                     if does_fragment_condition_match(
                         &Some(fragment.type_condition.clone()),
                         &parent_type,

--- a/src/ast/collect_fields.rs
+++ b/src/ast/collect_fields.rs
@@ -36,7 +36,7 @@ fn does_fragment_condition_match<'a>(
         if let Some(conditional_type) = context.schema.type_by_name(type_name) {
             if conditional_type
                 .name()
-                .eq(&current_selection_set_type.name())
+                .eq(current_selection_set_type.name())
             {
                 return true;
             }

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -11,23 +11,19 @@ use crate::static_graphql::schema::{
 };
 
 pub trait FieldByNameExtension {
-    fn field_by_name(&self, name: &String) -> Option<schema::Field>;
+    fn field_by_name(&self, name: &String) -> Option<&schema::Field>;
     fn input_field_by_name(&self, name: &String) -> Option<InputValue>;
 }
 
 impl FieldByNameExtension for TypeDefinition {
-    fn field_by_name(&self, name: &String) -> Option<schema::Field> {
+    fn field_by_name(&self, name: &String) -> Option<&schema::Field> {
         match self {
-            TypeDefinition::Object(object) => object
-                .fields
-                .iter()
-                .find(|field| field.name.eq(name))
-                .cloned(),
-            TypeDefinition::Interface(interface) => interface
-                .fields
-                .iter()
-                .find(|field| field.name.eq(name))
-                .cloned(),
+            TypeDefinition::Object(object) => {
+                object.fields.iter().find(|field| field.name.eq(name))
+            }
+            TypeDefinition::Interface(interface) => {
+                interface.fields.iter().find(|field| field.name.eq(name))
+            }
             _ => None,
         }
     }

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -309,7 +309,7 @@ impl TypeExtension for Type {
 
 pub trait ValueExtension {
     fn compare(&self, other: &Self) -> bool;
-    fn variables_in_use(&self) -> Vec<String>;
+    fn variables_in_use(&self) -> Vec<&str>;
 }
 
 impl ValueExtension for Value {
@@ -329,9 +329,9 @@ impl ValueExtension for Value {
         }
     }
 
-    fn variables_in_use(&self) -> Vec<String> {
+    fn variables_in_use(&self) -> Vec<&str> {
         match self {
-            Value::Variable(v) => vec![v.clone()],
+            Value::Variable(v) => vec![v],
             Value::List(list) => list.iter().flat_map(|v| v.variables_in_use()).collect(),
             Value::Object(object) => object
                 .iter()

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -682,27 +682,27 @@ impl AstNodeWithName for query::FragmentSpread {
 }
 
 pub trait FragmentSpreadExtraction {
-    fn get_recursive_fragment_spreads(&self) -> Vec<FragmentSpread>;
-    fn get_fragment_spreads(&self) -> Vec<FragmentSpread>;
+    fn get_recursive_fragment_spreads(&self) -> Vec<&FragmentSpread>;
+    fn get_fragment_spreads(&self) -> Vec<&FragmentSpread>;
 }
 
 impl FragmentSpreadExtraction for query::SelectionSet {
-    fn get_recursive_fragment_spreads(&self) -> Vec<FragmentSpread> {
+    fn get_recursive_fragment_spreads(&self) -> Vec<&FragmentSpread> {
         self.items
             .iter()
             .flat_map(|v| match v {
-                query::Selection::FragmentSpread(f) => vec![f.clone()],
+                query::Selection::FragmentSpread(f) => vec![f],
                 query::Selection::Field(f) => f.selection_set.get_fragment_spreads(),
                 query::Selection::InlineFragment(f) => f.selection_set.get_fragment_spreads(),
             })
             .collect()
     }
 
-    fn get_fragment_spreads(&self) -> Vec<FragmentSpread> {
+    fn get_fragment_spreads(&self) -> Vec<&FragmentSpread> {
         self.items
             .iter()
             .flat_map(|v| match v {
-                query::Selection::FragmentSpread(f) => vec![f.clone()],
+                query::Selection::FragmentSpread(f) => vec![f],
                 _ => vec![],
             })
             .collect()

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -261,7 +261,7 @@ impl SchemaDocumentExtension for schema::Document {
 }
 
 pub trait TypeExtension {
-    fn inner_type(&self) -> String;
+    fn inner_type(&self) -> &str;
     fn is_non_null(&self) -> bool;
     fn is_list_type(&self) -> bool;
     fn is_named_type(&self) -> bool;
@@ -269,9 +269,9 @@ pub trait TypeExtension {
 }
 
 impl TypeExtension for Type {
-    fn inner_type(&self) -> String {
+    fn inner_type(&self) -> &str {
         match self {
-            Type::NamedType(name) => name.clone(),
+            Type::NamedType(name) => name.as_str(),
             Type::ListType(child) => child.inner_type(),
             Type::NonNullType(child) => child.inner_type(),
         }

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -12,7 +12,7 @@ use crate::static_graphql::schema::{
 
 pub trait FieldByNameExtension {
     fn field_by_name(&self, name: &String) -> Option<&schema::Field>;
-    fn input_field_by_name(&self, name: &String) -> Option<InputValue>;
+    fn input_field_by_name(&self, name: &String) -> Option<&InputValue>;
 }
 
 impl FieldByNameExtension for TypeDefinition {
@@ -28,13 +28,11 @@ impl FieldByNameExtension for TypeDefinition {
         }
     }
 
-    fn input_field_by_name(&self, name: &String) -> Option<InputValue> {
+    fn input_field_by_name(&self, name: &String) -> Option<&InputValue> {
         match self {
-            TypeDefinition::InputObject(input_object) => input_object
-                .fields
-                .iter()
-                .find(|field| field.name.eq(name))
-                .cloned(),
+            TypeDefinition::InputObject(input_object) => {
+                input_object.fields.iter().find(|field| field.name.eq(name))
+            }
             _ => None,
         }
     }

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -655,29 +655,29 @@ impl TypeDefinitionExtension for schema::TypeDefinition {
 }
 
 pub trait AstNodeWithName {
-    fn node_name(&self) -> Option<String>;
+    fn node_name(&self) -> Option<&str>;
 }
 
 impl AstNodeWithName for query::OperationDefinition {
-    fn node_name(&self) -> Option<String> {
+    fn node_name(&self) -> Option<&str> {
         match self {
-            query::OperationDefinition::Query(q) => q.name.clone(),
+            query::OperationDefinition::Query(q) => q.name.as_deref(),
             query::OperationDefinition::SelectionSet(_s) => None,
-            query::OperationDefinition::Mutation(m) => m.name.clone(),
-            query::OperationDefinition::Subscription(s) => s.name.clone(),
+            query::OperationDefinition::Mutation(m) => m.name.as_deref(),
+            query::OperationDefinition::Subscription(s) => s.name.as_deref(),
         }
     }
 }
 
 impl AstNodeWithName for query::FragmentDefinition {
-    fn node_name(&self) -> Option<String> {
-        Some(self.name.clone())
+    fn node_name(&self) -> Option<&str> {
+        Some(&self.name)
     }
 }
 
 impl AstNodeWithName for query::FragmentSpread {
-    fn node_name(&self) -> Option<String> {
-        Some(self.fragment_name.clone())
+    fn node_name(&self) -> Option<&str> {
+        Some(&self.fragment_name)
     }
 }
 

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -500,7 +500,7 @@ impl AbstractTypeDefinitionExtension for InterfaceType {
     }
 }
 
-impl TypeDefinitionExtension for Option<schema::TypeDefinition> {
+impl TypeDefinitionExtension for Option<&schema::TypeDefinition> {
     fn is_leaf_type(&self) -> bool {
         match self {
             Some(t) => t.is_leaf_type(),

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -423,7 +423,7 @@ fn visit_selection_set<'a, Visitor, UserContext>(
 
 fn visit_fragment_definition<'a, Visitor, UserContext>(
     visitor: &mut Visitor,
-    fragment: &FragmentDefinition,
+    fragment: &'a FragmentDefinition,
     context: &mut OperationVisitorContext<'a>,
     user_context: &mut UserContext,
 ) where
@@ -476,7 +476,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &OperationDefinition,
+        _: &'a OperationDefinition,
     ) {
     }
     fn leave_operation_definition(
@@ -491,7 +491,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &FragmentDefinition,
+        _: &'a FragmentDefinition,
     ) {
     }
     fn leave_fragment_definition(

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -459,7 +459,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &Document,
+        _: &'a Document,
     ) {
     }
     fn leave_document(
@@ -549,7 +549,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &SelectionSet,
+        _: &'a SelectionSet,
     ) {
     }
     fn leave_selection_set(

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -236,7 +236,7 @@ fn visit_arguments<'a, Visitor, UserContext>(
 
 fn visit_input_value<'a, Visitor, UserContext>(
     visitor: &mut Visitor,
-    input_value: &Value,
+    input_value: &'a Value,
     context: &mut OperationVisitorContext<'a>,
     user_context: &mut UserContext,
 ) where
@@ -644,7 +644,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &String,
+        _: &'a str,
     ) {
     }
     fn leave_variable_value(

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -504,7 +504,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &VariableDefinition,
+        _: &'a VariableDefinition,
     ) {
     }
     fn leave_variable_definition(

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -188,7 +188,7 @@ fn visit_definitions<'a, Visitor, UserContext>(
 
 fn visit_directives<'a, Visitor, UserContext>(
     visitor: &mut Visitor,
-    directives: &[Directive],
+    directives: &'a [Directive],
     context: &mut OperationVisitorContext<'a>,
     user_context: &mut UserContext,
 ) where
@@ -215,7 +215,7 @@ fn visit_directives<'a, Visitor, UserContext>(
 fn visit_arguments<'a, Visitor, UserContext>(
     visitor: &mut Visitor,
     arguments_definition: Option<&'a Vec<schema::InputValue>>,
-    arguments: &Vec<(String, Value)>,
+    arguments: &'a Vec<(String, Value)>,
     context: &mut OperationVisitorContext<'a>,
     user_context: &mut UserContext,
 ) where
@@ -534,7 +534,7 @@ pub trait OperationVisitor<'a, UserContext = ()> {
         &mut self,
         _: &mut OperationVisitorContext<'a>,
         _: &mut UserContext,
-        _: &(String, Value),
+        _: &'a (String, Value),
     ) {
     }
     fn leave_argument(

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -26,7 +26,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownFragmentNames {
     ) {
         match visitor_context
             .known_fragments
-            .get(&fragment_spread.fragment_name)
+            .get(fragment_spread.fragment_name.as_str())
         {
             None => user_context.report_error(ValidationError {
                 locations: vec![fragment_spread.position],

--- a/src/validation/rules/no_fragments_cycle.rs
+++ b/src/validation/rules/no_fragments_cycle.rs
@@ -25,12 +25,12 @@ impl NoFragmentsCycle {
     /// This does a straight-forward DFS to find cycles.
     /// It does not terminate when a cycle was found but continues to explore
     /// the graph to find all possible cycles.
-    fn detect_cycles(
+    fn detect_cycles<'a>(
         &mut self,
-        fragment: &FragmentDefinition,
-        spread_paths: &mut Vec<FragmentSpread>,
+        fragment: &'a FragmentDefinition,
+        spread_paths: &mut Vec<&'a FragmentSpread>,
         spread_path_index_by_name: &mut HashMap<String, usize>,
-        known_fragments: &HashMap<String, FragmentDefinition>,
+        known_fragments: &'a HashMap<String, FragmentDefinition>,
         error_context: &mut ValidationErrorContext,
     ) {
         if self.visited_fragments.contains(&fragment.name) {
@@ -103,7 +103,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoFragmentsCycle {
         user_context: &mut ValidationErrorContext,
         fragment: &FragmentDefinition,
     ) {
-        let mut spread_paths: Vec<FragmentSpread> = vec![];
+        let mut spread_paths: Vec<&FragmentSpread> = vec![];
         let mut spread_path_index_by_name: HashMap<String, usize> = HashMap::new();
 
         self.detect_cycles(
@@ -190,7 +190,7 @@ fn double_spread_within_abstract_types() {
 			... on Dog { name }
 			... on Cat { name }
 		      }
-		
+
 		      fragment spreadsInAnon on Pet {
 			... on Dog { ...nameFragment }
 			... on Cat { ...nameFragment }

--- a/src/validation/rules/no_fragments_cycle.rs
+++ b/src/validation/rules/no_fragments_cycle.rs
@@ -30,7 +30,7 @@ impl NoFragmentsCycle {
         fragment: &'a FragmentDefinition,
         spread_paths: &mut Vec<&'a FragmentSpread>,
         spread_path_index_by_name: &mut HashMap<String, usize>,
-        known_fragments: &'a HashMap<String, FragmentDefinition>,
+        known_fragments: &'a HashMap<&'a str, &'a FragmentDefinition>,
         error_context: &mut ValidationErrorContext,
     ) {
         if self.visited_fragments.contains(&fragment.name) {
@@ -53,7 +53,7 @@ impl NoFragmentsCycle {
 
             match spread_path_index_by_name.get(&spread_name) {
                 None => {
-                    if let Some(spread_def) = known_fragments.get(&spread_name) {
+                    if let Some(spread_def) = known_fragments.get(spread_name.as_str()) {
                         self.detect_cycles(
                             spread_def,
                             spread_paths,

--- a/src/validation/rules/no_unused_fragments.rs
+++ b/src/validation/rules/no_unused_fragments.rs
@@ -9,19 +9,19 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// within operations, or spread within other fragments spread within operations.
 ///
 /// See https://spec.graphql.org/draft/#sec-Fragments-Must-Be-Used
-pub struct NoUnusedFragments {
-    fragments_in_use: Vec<String>,
+pub struct NoUnusedFragments<'a> {
+    fragments_in_use: Vec<&'a str>,
 }
 
-impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments {
+impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments<'a> {
     fn enter_fragment_spread(
         &mut self,
         _: &mut OperationVisitorContext,
         _: &mut ValidationErrorContext,
-        fragment_spread: &FragmentSpread,
+        fragment_spread: &'a FragmentSpread,
     ) {
         self.fragments_in_use
-            .push(fragment_spread.fragment_name.clone());
+            .push(fragment_spread.fragment_name.as_str());
     }
 
     fn leave_document(
@@ -49,7 +49,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments {
     }
 }
 
-impl NoUnusedFragments {
+impl<'a> NoUnusedFragments<'a> {
     pub fn new() -> Self {
         NoUnusedFragments {
             fragments_in_use: Vec::new(),
@@ -57,7 +57,7 @@ impl NoUnusedFragments {
     }
 }
 
-impl ValidationRule for NoUnusedFragments {
+impl<'n> ValidationRule for NoUnusedFragments<'n> {
     fn validate<'a>(
         &self,
         ctx: &'a mut OperationVisitorContext,

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -486,9 +486,9 @@ impl OverlappingFieldsCanBeMerged {
         &mut self,
         schema: &SchemaDocument,
         mutually_exclusive: bool,
-        parent_type_name1: Option<String>,
+        parent_type_name1: Option<&str>,
         selection_set1: &SelectionSet,
-        parent_type_name2: Option<String>,
+        parent_type_name2: Option<&str>,
         selection_set2: &SelectionSet,
         visited_fragments: &mut Vec<String>,
     ) -> Vec<Conflict> {

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -374,7 +374,7 @@ impl OverlappingFieldsCanBeMerged {
         // in the current state of the schema, then perhaps in some future version,
         // thus may not safely diverge.
         let mutually_exclusive = parents_mutually_exclusive
-            || (parent_type1.name().ne(&parent_type2.name())
+            || (parent_type1.name().ne(parent_type2.name())
                 && parent_type1.is_object_type()
                 && parent_type2.is_object_type());
 
@@ -497,9 +497,9 @@ impl OverlappingFieldsCanBeMerged {
         let parent_type2 = parent_type_name2.and_then(|t| schema.type_by_name(&t));
 
         let (field_map1, fragment_names1) =
-            self.get_fields_and_fragment_names(schema, parent_type1.as_ref(), selection_set1);
+            self.get_fields_and_fragment_names(schema, parent_type1, selection_set1);
         let (field_map2, fragment_names2) =
-            self.get_fields_and_fragment_names(schema, parent_type2.as_ref(), selection_set2);
+            self.get_fields_and_fragment_names(schema, parent_type2, selection_set2);
 
         // (H) First, collect all conflicts between these two collections of field.
         self.collect_conflicts_between(
@@ -694,7 +694,7 @@ impl OverlappingFieldsCanBeMerged {
         let TypeCondition::On(type_condition) = &fragment.type_condition;
         let fragment_type = schema.type_by_name(type_condition);
 
-        self.get_fields_and_fragment_names(schema, fragment_type.as_ref(), &fragment.selection_set)
+        self.get_fields_and_fragment_names(schema, fragment_type, &fragment.selection_set)
     }
 
     // Collect all Conflicts between two collections of fields. This is similar to,
@@ -800,11 +800,11 @@ impl OverlappingFieldsCanBeMerged {
 
                             schema.type_by_name(type_condition)
                         })
-                        .or(parent_type.cloned());
+                        .or(parent_type);
 
                     self.collect_fields_and_fragment_names(
                         schema,
-                        fragment_type.as_ref(),
+                        fragment_type,
                         &inline_fragment.selection_set,
                         ast_and_defs,
                         fragment_names,

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -23,9 +23,9 @@ use std::hash::Hash;
 /// without ambiguity.
 ///
 /// See https://spec.graphql.org/draft/#sec-Field-Selection-Merging
-pub struct OverlappingFieldsCanBeMerged {
-    named_fragments: HashMap<String, FragmentDefinition>,
-    compared_fragments: PairSet,
+pub struct OverlappingFieldsCanBeMerged<'a> {
+    named_fragments: HashMap<&'a str, &'a FragmentDefinition>,
+    compared_fragments: PairSet<'a>,
 }
 
 /**
@@ -90,7 +90,11 @@ struct Conflict(ConflictReason, Vec<Pos>, Vec<Pos>);
 struct ConflictReason(String, ConflictReasonMessage);
 
 #[derive(Debug)]
-struct AstAndDef<'a>(Option<TypeDefinition>, Field, Option<&'a FieldDefinition>);
+struct AstAndDef<'a>(
+    Option<&'a TypeDefinition>,
+    &'a Field,
+    Option<&'a FieldDefinition>,
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum ConflictReasonMessage {
@@ -98,8 +102,8 @@ enum ConflictReasonMessage {
     Nested(Vec<ConflictReason>),
 }
 
-struct PairSet {
-    data: HashMap<String, HashMap<String, bool>>,
+struct PairSet<'a> {
+    data: HashMap<&'a str, HashMap<&'a str, bool>>,
 }
 
 struct OrderedMap<K, V> {
@@ -170,14 +174,14 @@ impl<'a, K: Eq + Hash + 'a, V: 'a> Iterator for OrderedMapIter<'a, K, V> {
     }
 }
 
-impl PairSet {
-    fn new() -> PairSet {
+impl<'a> PairSet<'a> {
+    fn new() -> PairSet<'a> {
         PairSet {
             data: HashMap::new(),
         }
     }
 
-    pub fn contains(&self, a: &String, b: &String, mutex: bool) -> bool {
+    pub fn contains(&self, a: &str, b: &str, mutex: bool) -> bool {
         if let Some(result) = self.data.get(a).and_then(|s| s.get(b)) {
             if !mutex {
                 !result
@@ -189,20 +193,20 @@ impl PairSet {
         }
     }
 
-    pub fn insert(&mut self, a: &String, b: &String, mutex: bool) {
+    pub fn insert(&mut self, a: &'a str, b: &'a str, mutex: bool) {
         self.data
-            .entry(a.clone())
+            .entry(a)
             .or_insert_with(HashMap::new)
-            .insert(b.clone(), mutex);
+            .insert(b, mutex);
 
         self.data
-            .entry(b.clone())
+            .entry(b)
             .or_insert_with(HashMap::new)
-            .insert(a.clone(), mutex);
+            .insert(a, mutex);
     }
 }
 
-impl OverlappingFieldsCanBeMerged {
+impl<'a> OverlappingFieldsCanBeMerged<'a> {
     pub fn new() -> Self {
         Self {
             named_fragments: HashMap::new(),
@@ -215,10 +219,10 @@ impl OverlappingFieldsCanBeMerged {
     // GraphQL Document.
     fn find_conflicts_within_selection_set(
         &mut self,
-        schema: &SchemaDocument,
-        parent_type: Option<&TypeDefinition>,
-        selection_set: &SelectionSet,
-        visited_fragments: &mut Vec<String>,
+        schema: &'a SchemaDocument,
+        parent_type: Option<&'a TypeDefinition>,
+        selection_set: &'a SelectionSet,
+        visited_fragments: &mut Vec<&'a str>,
     ) -> Vec<Conflict> {
         let mut conflicts = Vec::<Conflict>::new();
 
@@ -263,10 +267,10 @@ impl OverlappingFieldsCanBeMerged {
     // Collect all Conflicts "within" one collection of fields.
     fn collect_conflicts_within(
         &mut self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         conflicts: &mut Vec<Conflict>,
-        field_map: &OrderedMap<String, Vec<AstAndDef>>,
-        visited_fragments: &mut Vec<String>,
+        field_map: &OrderedMap<&'a str, Vec<AstAndDef<'a>>>,
+        visited_fragments: &mut Vec<&'a str>,
     ) {
         // A field map is a keyed collection, where each key represents a response
         // name and the value at that key is a list of all fields which provide that
@@ -355,15 +359,15 @@ impl OverlappingFieldsCanBeMerged {
     // comparing their sub-fields.
     fn find_conflict(
         &mut self,
-        schema: &SchemaDocument,
-        out_field_name: &String,
-        first: &AstAndDef,
-        second: &AstAndDef,
+        schema: &'a SchemaDocument,
+        out_field_name: &str,
+        first: &AstAndDef<'a>,
+        second: &AstAndDef<'a>,
         parents_mutually_exclusive: bool,
-        visited_fragments: &mut Vec<String>,
+        visited_fragments: &mut Vec<&'a str>,
     ) -> Option<Conflict> {
-        let AstAndDef(ref parent_type1, ref field1, ref field1_def) = *first;
-        let AstAndDef(ref parent_type2, ref field2, ref field2_def) = *second;
+        let AstAndDef(parent_type1, field1, field1_def) = *first;
+        let AstAndDef(parent_type2, field2, field2_def) = *second;
 
         // If it is known that two fields could not possibly apply at the same
         // time, due to the parent types, then it is safe to permit them to diverge
@@ -385,7 +389,7 @@ impl OverlappingFieldsCanBeMerged {
             if name1 != name2 {
                 return Some(Conflict(
                     ConflictReason(
-                        out_field_name.clone(),
+                        out_field_name.to_string(),
                         ConflictReasonMessage::Message(format!(
                             "\"{}\" and \"{}\" are different fields",
                             name1, name2
@@ -399,7 +403,7 @@ impl OverlappingFieldsCanBeMerged {
             if !self.is_same_arguments(&field1.arguments, &field2.arguments) {
                 return Some(Conflict(
                     ConflictReason(
-                        out_field_name.clone(),
+                        out_field_name.to_string(),
                         ConflictReasonMessage::Message("they have differing arguments".to_string()),
                     ),
                     vec![field1.position],
@@ -455,7 +459,7 @@ impl OverlappingFieldsCanBeMerged {
     fn subfield_conflicts(
         &self,
         conflicts: &Vec<Conflict>,
-        out_field_name: &String,
+        out_field_name: &str,
         f1_pos: Pos,
         f2_pos: Pos,
     ) -> Option<Conflict> {
@@ -465,7 +469,7 @@ impl OverlappingFieldsCanBeMerged {
 
         Some(Conflict(
             ConflictReason(
-                out_field_name.clone(),
+                out_field_name.to_string(),
                 ConflictReasonMessage::Nested(conflicts.iter().map(|v| v.0.clone()).collect()),
             ),
             vec![f1_pos]
@@ -484,13 +488,13 @@ impl OverlappingFieldsCanBeMerged {
     // between the sub-fields of two overlapping fields.
     fn find_conflicts_between_sub_selection_sets(
         &mut self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         mutually_exclusive: bool,
         parent_type_name1: Option<&str>,
-        selection_set1: &SelectionSet,
+        selection_set1: &'a SelectionSet,
         parent_type_name2: Option<&str>,
-        selection_set2: &SelectionSet,
-        visited_fragments: &mut Vec<String>,
+        selection_set2: &'a SelectionSet,
+        visited_fragments: &mut Vec<&'a str>,
     ) -> Vec<Conflict> {
         let mut conflicts = Vec::<Conflict>::new();
         let parent_type1 = parent_type_name1.and_then(|t| schema.type_by_name(&t));
@@ -558,12 +562,12 @@ impl OverlappingFieldsCanBeMerged {
 
     fn collect_conflicts_between_fields_and_fragment(
         &mut self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         conflicts: &mut Vec<Conflict>,
-        field_map: &OrderedMap<String, Vec<AstAndDef>>,
-        fragment_name: &String,
+        field_map: &OrderedMap<&'a str, Vec<AstAndDef<'a>>>,
+        fragment_name: &str,
         mutually_exclusive: bool,
-        visited_fragments: &mut Vec<String>,
+        visited_fragments: &mut Vec<&'a str>,
     ) {
         let fragment = match self.named_fragments.get(fragment_name) {
             Some(f) => f,
@@ -573,7 +577,7 @@ impl OverlappingFieldsCanBeMerged {
         let (field_map2, fragment_names2) =
             self.get_referenced_fields_and_fragment_names(schema, fragment);
 
-        if fragment_names2.contains(fragment_name) {
+        if fragment_names2.contains(&fragment_name) {
             return;
         }
 
@@ -591,7 +595,7 @@ impl OverlappingFieldsCanBeMerged {
                 return;
             }
 
-            visited_fragments.push(fragment_name2.clone());
+            visited_fragments.push(fragment_name2);
 
             self.collect_conflicts_between_fields_and_fragment(
                 schema,
@@ -608,12 +612,12 @@ impl OverlappingFieldsCanBeMerged {
     // any nested fragments.
     fn collect_conflicts_between_fragments(
         &mut self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         conflicts: &mut Vec<Conflict>,
-        fragment_name1: &String,
-        fragment_name2: &String,
+        fragment_name1: &'a str,
+        fragment_name2: &'a str,
         mutually_exclusive: bool,
-        visited_fragments: &mut Vec<String>,
+        visited_fragments: &mut Vec<&'a str>,
     ) {
         // No need to compare a fragment to itself.
         if fragment_name1.eq(fragment_name2) {
@@ -686,11 +690,11 @@ impl OverlappingFieldsCanBeMerged {
 
     // Given a reference to a fragment, return the represented collection of fields
     // as well as a list of nested fragment names referenced via fragment spreads.
-    fn get_referenced_fields_and_fragment_names<'a>(
+    fn get_referenced_fields_and_fragment_names(
         &self,
         schema: &'a SchemaDocument,
-        fragment: &FragmentDefinition,
-    ) -> (OrderedMap<String, Vec<AstAndDef<'a>>>, Vec<String>) {
+        fragment: &'a FragmentDefinition,
+    ) -> (OrderedMap<&'a str, Vec<AstAndDef<'a>>>, Vec<&'a str>) {
         let TypeCondition::On(type_condition) = &fragment.type_condition;
         let fragment_type = schema.type_by_name(type_condition);
 
@@ -702,14 +706,14 @@ impl OverlappingFieldsCanBeMerged {
     // assumes that `collectConflictsWithin` has already been called on each
     // provided collection of fields. This is true because this validator traverses
     // each individual selection set.
-    fn collect_conflicts_between<'a>(
+    fn collect_conflicts_between(
         &mut self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         conflicts: &mut Vec<Conflict>,
         mutually_exclusive: bool,
-        field_map1: &OrderedMap<String, Vec<AstAndDef<'a>>>,
-        field_map2: &OrderedMap<String, Vec<AstAndDef<'a>>>,
-        visited_fragments: &'a mut Vec<String>,
+        field_map1: &OrderedMap<&'a str, Vec<AstAndDef<'a>>>,
+        field_map2: &OrderedMap<&'a str, Vec<AstAndDef<'a>>>,
+        visited_fragments: &mut Vec<&'a str>,
     ) {
         // A field map is a keyed collection, where each key represents a response
         // name and the value at that key is a list of all fields which provide that
@@ -739,14 +743,14 @@ impl OverlappingFieldsCanBeMerged {
     // Given a selection set, return the collection of fields (a mapping of response
     // name to field nodes and definitions) as well as a list of fragment names
     // referenced via fragment spreads.
-    fn get_fields_and_fragment_names<'a>(
+    fn get_fields_and_fragment_names(
         &self,
         schema: &'a SchemaDocument,
         parent_type: Option<&'a TypeDefinition>,
-        selection_set: &SelectionSet,
-    ) -> (OrderedMap<String, Vec<AstAndDef<'a>>>, Vec<String>) {
-        let mut ast_and_defs = OrderedMap::<String, Vec<AstAndDef>>::new();
-        let mut fragment_names = Vec::<String>::new();
+        selection_set: &'a SelectionSet,
+    ) -> (OrderedMap<&'a str, Vec<AstAndDef<'a>>>, Vec<&'a str>) {
+        let mut ast_and_defs = OrderedMap::new();
+        let mut fragment_names = Vec::new();
 
         self.collect_fields_and_fragment_names(
             schema,
@@ -759,20 +763,20 @@ impl OverlappingFieldsCanBeMerged {
         (ast_and_defs, fragment_names)
     }
 
-    fn collect_fields_and_fragment_names<'a>(
+    fn collect_fields_and_fragment_names(
         &self,
         schema: &'a SchemaDocument,
         parent_type: Option<&'a TypeDefinition>,
-        selection_set: &SelectionSet,
-        ast_and_defs: &mut OrderedMap<String, Vec<AstAndDef<'a>>>,
-        fragment_names: &mut Vec<String>,
+        selection_set: &'a SelectionSet,
+        ast_and_defs: &mut OrderedMap<&'a str, Vec<AstAndDef<'a>>>,
+        fragment_names: &mut Vec<&'a str>,
     ) {
         for selection in &selection_set.items {
             match selection {
                 Selection::Field(field) => {
                     let field_name = &field.name;
                     let field_def = parent_type.and_then(|t| t.field_by_name(field_name));
-                    let out_field_name = field.alias.as_ref().unwrap_or(field_name);
+                    let out_field_name = field.alias.as_ref().unwrap_or(field_name).as_str();
 
                     if !ast_and_defs.contains_key(out_field_name) {
                         ast_and_defs.insert(out_field_name.clone(), Vec::new());
@@ -781,14 +785,14 @@ impl OverlappingFieldsCanBeMerged {
                     ast_and_defs
                         .get_mut(out_field_name)
                         .unwrap()
-                        .push(AstAndDef(parent_type.cloned(), field.clone(), field_def));
+                        .push(AstAndDef(parent_type, field, field_def));
                 }
                 Selection::FragmentSpread(fragment_spread) => {
                     if let None = fragment_names
                         .iter()
                         .find(|n| (*n).eq(&fragment_spread.fragment_name))
                     {
-                        fragment_names.push(fragment_spread.fragment_name.clone());
+                        fragment_names.push(&fragment_spread.fragment_name);
                     }
                 }
                 Selection::InlineFragment(inline_fragment) => {
@@ -815,30 +819,29 @@ impl OverlappingFieldsCanBeMerged {
     }
 }
 
-impl<'a> OperationVisitor<'a, ValidationErrorContext> for OverlappingFieldsCanBeMerged {
+impl<'a> OperationVisitor<'a, ValidationErrorContext> for OverlappingFieldsCanBeMerged<'a> {
     fn enter_document(
         &mut self,
         _visitor_context: &mut OperationVisitorContext,
         _: &mut ValidationErrorContext,
-        document: &Document,
+        document: &'a Document,
     ) {
         for definition in &document.definitions {
             if let Definition::Fragment(fragment) = definition {
-                self.named_fragments
-                    .insert(fragment.name.clone(), fragment.clone());
+                self.named_fragments.insert(&fragment.name, &fragment);
             }
         }
     }
 
     fn enter_selection_set(
         &mut self,
-        visitor_context: &mut OperationVisitorContext,
+        visitor_context: &mut OperationVisitorContext<'a>,
         user_context: &mut ValidationErrorContext,
-        selection_set: &SelectionSet,
+        selection_set: &'a SelectionSet,
     ) {
         let parent_type = visitor_context.current_parent_type();
         let schema = visitor_context.schema;
-        let mut visited_fragments = Vec::<String>::new();
+        let mut visited_fragments = Vec::new();
         let found_conflicts = self.find_conflicts_within_selection_set(
             &schema,
             parent_type,
@@ -885,7 +888,7 @@ fn format_reason(reason: &ConflictReasonMessage) -> String {
     }
 }
 
-impl ValidationRule for OverlappingFieldsCanBeMerged {
+impl<'o> ValidationRule for OverlappingFieldsCanBeMerged<'o> {
     fn validate<'a>(
         &self,
         ctx: &'a mut OperationVisitorContext,

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -90,7 +90,7 @@ struct Conflict(ConflictReason, Vec<Pos>, Vec<Pos>);
 struct ConflictReason(String, ConflictReasonMessage);
 
 #[derive(Debug)]
-struct AstAndDef(Option<TypeDefinition>, Field, Option<FieldDefinition>);
+struct AstAndDef<'a>(Option<TypeDefinition>, Field, Option<&'a FieldDefinition>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum ConflictReasonMessage {
@@ -686,11 +686,11 @@ impl OverlappingFieldsCanBeMerged {
 
     // Given a reference to a fragment, return the represented collection of fields
     // as well as a list of nested fragment names referenced via fragment spreads.
-    fn get_referenced_fields_and_fragment_names(
+    fn get_referenced_fields_and_fragment_names<'a>(
         &self,
-        schema: &SchemaDocument,
+        schema: &'a SchemaDocument,
         fragment: &FragmentDefinition,
-    ) -> (OrderedMap<String, Vec<AstAndDef>>, Vec<String>) {
+    ) -> (OrderedMap<String, Vec<AstAndDef<'a>>>, Vec<String>) {
         let TypeCondition::On(type_condition) = &fragment.type_condition;
         let fragment_type = schema.type_by_name(type_condition);
 
@@ -702,14 +702,14 @@ impl OverlappingFieldsCanBeMerged {
     // assumes that `collectConflictsWithin` has already been called on each
     // provided collection of fields. This is true because this validator traverses
     // each individual selection set.
-    fn collect_conflicts_between(
+    fn collect_conflicts_between<'a>(
         &mut self,
         schema: &SchemaDocument,
         conflicts: &mut Vec<Conflict>,
         mutually_exclusive: bool,
-        field_map1: &OrderedMap<String, Vec<AstAndDef>>,
-        field_map2: &OrderedMap<String, Vec<AstAndDef>>,
-        visited_fragments: &mut Vec<String>,
+        field_map1: &OrderedMap<String, Vec<AstAndDef<'a>>>,
+        field_map2: &OrderedMap<String, Vec<AstAndDef<'a>>>,
+        visited_fragments: &'a mut Vec<String>,
     ) {
         // A field map is a keyed collection, where each key represents a response
         // name and the value at that key is a list of all fields which provide that
@@ -739,12 +739,12 @@ impl OverlappingFieldsCanBeMerged {
     // Given a selection set, return the collection of fields (a mapping of response
     // name to field nodes and definitions) as well as a list of fragment names
     // referenced via fragment spreads.
-    fn get_fields_and_fragment_names(
+    fn get_fields_and_fragment_names<'a>(
         &self,
-        schema: &SchemaDocument,
-        parent_type: Option<&TypeDefinition>,
+        schema: &'a SchemaDocument,
+        parent_type: Option<&'a TypeDefinition>,
         selection_set: &SelectionSet,
-    ) -> (OrderedMap<String, Vec<AstAndDef>>, Vec<String>) {
+    ) -> (OrderedMap<String, Vec<AstAndDef<'a>>>, Vec<String>) {
         let mut ast_and_defs = OrderedMap::<String, Vec<AstAndDef>>::new();
         let mut fragment_names = Vec::<String>::new();
 
@@ -759,12 +759,12 @@ impl OverlappingFieldsCanBeMerged {
         (ast_and_defs, fragment_names)
     }
 
-    fn collect_fields_and_fragment_names(
+    fn collect_fields_and_fragment_names<'a>(
         &self,
-        schema: &SchemaDocument,
-        parent_type: Option<&TypeDefinition>,
+        schema: &'a SchemaDocument,
+        parent_type: Option<&'a TypeDefinition>,
         selection_set: &SelectionSet,
-        ast_and_defs: &mut OrderedMap<String, Vec<AstAndDef>>,
+        ast_and_defs: &mut OrderedMap<String, Vec<AstAndDef<'a>>>,
         fragment_names: &mut Vec<String>,
     ) {
         for selection in &selection_set.items {

--- a/src/validation/rules/possible_fragment_spreads.rs
+++ b/src/validation/rules/possible_fragment_spreads.rs
@@ -37,7 +37,7 @@ pub fn do_types_overlap(
     t1: &schema::TypeDefinition,
     t2: &schema::TypeDefinition,
 ) -> bool {
-    if t1.name().eq(&t2.name()) {
+    if t1.name().eq(t2.name()) {
         return true;
     }
 

--- a/src/validation/rules/possible_fragment_spreads.rs
+++ b/src/validation/rules/possible_fragment_spreads.rs
@@ -5,7 +5,7 @@ use crate::ast::{
     PossibleTypesExtension, SchemaDocumentExtension,
 };
 use crate::static_graphql::query::TypeCondition;
-use crate::static_graphql::schema::{self, TypeDefinition};
+use crate::static_graphql::schema;
 use crate::validation::utils::{ValidationError, ValidationErrorContext};
 
 /// Possible fragment spread
@@ -47,9 +47,7 @@ pub fn do_types_overlap(
 
             return possible_types
                 .into_iter()
-                .filter(|possible_type| {
-                    t2.has_sub_type(&TypeDefinition::Object(possible_type.clone()))
-                })
+                .filter(|possible_type| t2.has_concrete_sub_type(possible_type))
                 .count()
                 > 0;
         }

--- a/src/validation/rules/possible_fragment_spreads.rs
+++ b/src/validation/rules/possible_fragment_spreads.rs
@@ -92,7 +92,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for PossibleFragmentSpread
     ) {
         if let Some(actual_fragment) = visitor_context
             .known_fragments
-            .get(&fragment_spread.fragment_name)
+            .get(fragment_spread.fragment_name.as_str())
         {
             let TypeCondition::On(fragment_type_name) = &actual_fragment.type_condition;
 

--- a/src/validation/rules/unique_fragment_names.rs
+++ b/src/validation/rules/unique_fragment_names.rs
@@ -10,16 +10,16 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// A GraphQL document is only valid if all defined fragments have unique names.
 ///
 /// See https://spec.graphql.org/draft/#sec-Fragment-Name-Uniqueness
-pub struct UniqueFragmentNames {
-    findings_counter: HashMap<String, i32>,
+pub struct UniqueFragmentNames<'a> {
+    findings_counter: HashMap<&'a str, i32>,
 }
 
-impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueFragmentNames {
+impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueFragmentNames<'a> {
     fn enter_fragment_definition(
         &mut self,
         _: &mut OperationVisitorContext,
         _: &mut ValidationErrorContext,
-        fragment: &FragmentDefinition,
+        fragment: &'a FragmentDefinition,
     ) {
         if let Some(name) = fragment.node_name() {
             self.store_finding(&name);
@@ -27,20 +27,20 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueFragmentNames {
     }
 }
 
-impl UniqueFragmentNames {
+impl<'a> UniqueFragmentNames<'a> {
     pub fn new() -> Self {
         Self {
             findings_counter: HashMap::new(),
         }
     }
 
-    fn store_finding(&mut self, name: &String) {
-        let value = *self.findings_counter.entry(name.clone()).or_insert(0);
+    fn store_finding(&mut self, name: &'a str) {
+        let value = *self.findings_counter.entry(name).or_insert(0);
         self.findings_counter.insert(name.clone(), value + 1);
     }
 }
 
-impl ValidationRule for UniqueFragmentNames {
+impl<'u> ValidationRule for UniqueFragmentNames<'u> {
     fn validate<'a>(
         &self,
         ctx: &'a mut OperationVisitorContext,


### PR DESCRIPTION
Note that that also changes a lot of uses of &String to &str though that's debatable: a &String is just one pointer (8 bytes on a 64 bit machine), a &str is 16 bytes but accessing a &String requires two dereferences whereas &str only takes one and so using &str is a little faster at the expense of using a bit more memory.