### PR TITLE
Cleanup code, and allow to use `graphql_parser_hive_fork` instead of `graphql_parser`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,10 +30,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "byteorder"
-version = "1.4.3"
+name = "bytes"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "cc"
@@ -78,15 +72,12 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "3.8.1"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
- "ascii",
- "byteorder",
- "either",
+ "bytes",
  "memchr",
- "unreachable",
 ]
 
 [[package]]
@@ -175,22 +166,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "graphql-parser"
-version = "0.4.0"
+name = "graphql-parser-hive-fork"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
+checksum = "8a0137d5de726e9c6ddb3e6abcddc4fc3fd1c1cfcf23667388b6ccec9fa6433f"
 dependencies = [
  "combine",
  "thiserror",
@@ -200,7 +185,7 @@ dependencies = [
 name = "graphql-tools"
 version = "0.2.5"
 dependencies = [
- "graphql-parser",
+ "graphql-parser-hive-fork",
  "lazy_static",
  "serde",
  "serde_json",
@@ -509,21 +494,6 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +34,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -68,6 +80,19 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
 ]
 
 [[package]]
@@ -166,10 +191,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "graphql-parser"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
+dependencies = [
+ "combine 3.8.1",
+ "thiserror",
+]
 
 [[package]]
 name = "graphql-parser-hive-fork"
@@ -177,7 +218,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0137d5de726e9c6ddb3e6abcddc4fc3fd1c1cfcf23667388b6ccec9fa6433f"
 dependencies = [
- "combine",
+ "combine 4.6.7",
  "thiserror",
 ]
 
@@ -185,6 +226,7 @@ dependencies = [
 name = "graphql-tools"
 version = "0.2.5"
 dependencies = [
+ "graphql-parser",
  "graphql-parser-hive-fork",
  "lazy_static",
  "serde",
@@ -494,6 +536,21 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,14 @@ documentation = "https://github.com/dotansimha/graphql-tools-rs"
 authors = ["Dotan Simha <dotansimha@gmail.com>"]
 
 [dependencies]
-graphql-parser = { version = "0.5.0", package = "graphql-parser-hive-fork" }
+graphql-parser = { version = "^0.4.0", optional = true }
+graphql-parser-hive-fork = { version = "^0.5.0", optional = true }
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2.0"
 
-[dev-dependencies]
-graphql-parser = { version = "0.5.0", package = "graphql-parser-hive-fork" }
+[features]
+default = ["graphql_parser"]
+graphql_parser_fork = ["dep:graphql-parser-hive-fork"]
+graphql_parser = ["dep:graphql-parser"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://github.com/dotansimha/graphql-tools-rs"
 authors = ["Dotan Simha <dotansimha@gmail.com>"]
 
 [dependencies]
-graphql-parser = "^0.4.0"
+graphql-parser = { version = "0.5.0", package = "graphql-parser-hive-fork" }
 lazy_static = "1.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = "2.2.0"
 
 [dev-dependencies]
-graphql-parser = "0.4.0"
+graphql-parser = { version = "0.5.0", package = "graphql-parser-hive-fork" }

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [Documentation](https://docs.rs/graphql-tools) | [Crate](https://crates.io/crates/graphql-tools) | [GitHub](https://github.com/dotansimha/graphql-tools-rs)
 
-> **Note: this crate is still under development (see roadmap below)**
-
 The [`graphql_tools` crate](https://crates.io/crates/graphql-tools) implements tooling around GraphQL for Rust libraries. Most of the tools are based on `trait`s and `struct`s implemented in [`graphql_parser` crate](https://crates.io/crates/graphql-parser).
 
 The goal of this library is to create a common layer of tools that has similar/improved APIs to [`graphql-js` reference implementation](https://github.com/graphql/graphql-js) and [`graphql-tools` from the JS/TS ecosystem](https://github.com/ardatan/graphql-tools).
@@ -25,23 +23,16 @@ Or, if you are using [`cargo-edit`](https://github.com/killercup/cargo-edit):
 cargo add graphql-tools
 ```
 
-### Roadmap and progress
+By default, this crate is using the [`graphql-parser`](https://github.com/graphql-rust/graphql-parser) library for parsing. If you wish to use an alternative implementation such as [`graphql-hive/graphql-parser-hive-fork`](https://github.com/graphql-hive/graphql-parser-hive-fork), use the following `features` setup:
 
-- [ ] Better documentation 
-- [x] AST Visitor for GraphQL schema (`graphql_parser::schema::Document`)
-- [x] AST Visitor for GraphQL operations (`graphql_parser::operation::Document`) 
-- [x] AST Visitor with TypeInfo
-- [x] AST tools (ongoing)
-- [x] `struct` extensions
-- [x] GraphQL Validation engine
-- [x] Validation rules
-- [x] GraphQL operations transformer
-
-> If you have an idea / missing feature, feel free to open an issue / start a GitHub discussion!
+```toml
+[dependencies]
+graphql-tools = { version = "...", features = "graphql_parser_fork", default-features = false }
+```
 
 #### Validation Rules
 
-> This comparison is based on `graphql-js` refernece implementation. 
+> This comparison is based on `graphql-js` refernece implementation.
 
 - [x] ExecutableDefinitions (not actually needed)
 - [x] UniqueOperationNames

--- a/src/ast/ext.rs
+++ b/src/ast/ext.rs
@@ -621,31 +621,19 @@ impl TypeDefinitionExtension for schema::TypeDefinition {
     }
 
     fn is_object_type(&self) -> bool {
-        match self {
-            schema::TypeDefinition::Object(_o) => true,
-            _ => false,
-        }
+        matches!(self, schema::TypeDefinition::Object(_o))
     }
 
     fn is_union_type(&self) -> bool {
-        match self {
-            schema::TypeDefinition::Union(_o) => true,
-            _ => false,
-        }
+        matches!(self, schema::TypeDefinition::Union(_o))
     }
 
     fn is_enum_type(&self) -> bool {
-        match self {
-            schema::TypeDefinition::Enum(_o) => true,
-            _ => false,
-        }
+        matches!(self, schema::TypeDefinition::Enum(_o))
     }
 
     fn is_scalar_type(&self) -> bool {
-        match self {
-            schema::TypeDefinition::Scalar(_o) => true,
-            _ => false,
-        }
+        matches!(self, schema::TypeDefinition::Scalar(_o))
     }
 }
 

--- a/src/ast/operation_transformer.rs
+++ b/src/ast/operation_transformer.rs
@@ -370,7 +370,7 @@ pub trait OperationTransformer<'a, T: Text<'a> + Clone> {
 
     fn transform_directives(
         &mut self,
-        directives: &Vec<Directive<'a, T>>,
+        directives: &[Directive<'a, T>],
     ) -> TransformedValue<Vec<Directive<'a, T>>> {
         self.transform_list(directives, Self::transform_directive)
     }
@@ -452,7 +452,7 @@ pub trait OperationTransformer<'a, T: Text<'a> + Clone> {
 
     fn default_transform_variable_definitions(
         &mut self,
-        variable_definitions: &Vec<VariableDefinition<'a, T>>,
+        variable_definitions: &[VariableDefinition<'a, T>],
     ) -> TransformedValue<Vec<VariableDefinition<'a, T>>> {
         self.transform_list(
             variable_definitions,

--- a/src/ast/operation_transformer.rs
+++ b/src/ast/operation_transformer.rs
@@ -31,9 +31,9 @@ impl<T> TransformedValue<T> {
     }
 }
 
-impl<T> Into<Transformed<T>> for TransformedValue<T> {
-    fn into(self) -> Transformed<T> {
-        match self {
+impl<T> From<TransformedValue<T>> for Transformed<T> {
+    fn from(val: TransformedValue<T>) -> Self {
+        match val {
             TransformedValue::Keep => Transformed::Keep,
             TransformedValue::Replace(replacement) => Transformed::Replace(replacement),
         }
@@ -417,7 +417,7 @@ pub trait OperationTransformer<'a, T: Text<'a> + Clone> {
     ) -> Transformed<(T::Value, Value<'a, T>)> {
         let (name, value) = argument;
 
-        match self.transform_value(&value) {
+        match self.transform_value(value) {
             TransformedValue::Keep => Transformed::Keep,
             TransformedValue::Replace(replacement) => {
                 Transformed::Replace((name.clone(), replacement))
@@ -486,7 +486,7 @@ pub trait OperationTransformer<'a, T: Text<'a> + Clone> {
             }
         }
 
-        return TransformedValue::Keep;
+        TransformedValue::Keep
     }
 
     fn transform_list<I, F, R>(&mut self, list: &[I], f: F) -> TransformedValue<Vec<I>>

--- a/src/ast/operation_transformer.rs
+++ b/src/ast/operation_transformer.rs
@@ -1,4 +1,4 @@
-use graphql_parser::query::*;
+use crate::parser::query::*;
 
 #[derive(Clone, Debug)]
 pub enum Transformed<T> {

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use graphql_parser::query::TypeCondition;
+use crate::parser::query::TypeCondition;
 
 use crate::static_graphql::{
     query::{self, *},
@@ -278,7 +278,8 @@ fn visit_input_value<'a, Visitor, UserContext>(
                 let input_type = context
                     .current_input_type_literal()
                     .and_then(|v| context.schema.type_by_name(v.inner_type()))
-                    .and_then(|v| v.input_field_by_name(sub_key)).map(|v| &v.value_type);
+                    .and_then(|v| v.input_field_by_name(sub_key))
+                    .map(|v| &v.value_type);
 
                 context.with_input_type(input_type, |context| {
                     let param = &(sub_key.clone(), sub_value.clone());

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -55,11 +55,11 @@ impl<'a> OperationVisitorContext<'a> {
 
     pub fn with_type<Func>(&mut self, t: Option<&Type>, func: Func)
     where
-        Func: FnOnce(&mut OperationVisitorContext<'a>) -> (),
+        Func: FnOnce(&mut OperationVisitorContext<'a>),
     {
         if let Some(t) = t {
             self.type_stack
-                .push(self.schema.type_by_name(&t.inner_type()));
+                .push(self.schema.type_by_name(t.inner_type()));
         } else {
             self.type_stack.push(None);
         }
@@ -72,17 +72,17 @@ impl<'a> OperationVisitorContext<'a> {
 
     pub fn with_parent_type<Func>(&mut self, func: Func)
     where
-        Func: FnOnce(&mut OperationVisitorContext<'a>) -> (),
+        Func: FnOnce(&mut OperationVisitorContext<'a>),
     {
         self.parent_type_stack
-            .push(self.type_stack.last().unwrap_or(&None).clone());
+            .push(*self.type_stack.last().unwrap_or(&None));
         func(self);
         self.parent_type_stack.pop();
     }
 
     pub fn with_field<'f, Func>(&mut self, f: Option<&'f schema::Field>, func: Func)
     where
-        Func: FnOnce(&mut OperationVisitorContext<'a>) -> (),
+        Func: FnOnce(&mut OperationVisitorContext<'a>),
         'f: 'a,
     {
         if let Some(f) = f {
@@ -97,11 +97,11 @@ impl<'a> OperationVisitorContext<'a> {
 
     pub fn with_input_type<Func>(&mut self, t: Option<&'a Type>, func: Func)
     where
-        Func: FnOnce(&mut OperationVisitorContext<'a>) -> (),
+        Func: FnOnce(&mut OperationVisitorContext<'a>),
     {
-        if let Some(ref t) = t {
+        if let Some(t) = t {
             self.input_type_stack
-                .push(self.schema.type_by_name(&t.inner_type()));
+                .push(self.schema.type_by_name(t.inner_type()));
         } else {
             self.input_type_stack.push(None);
         }
@@ -277,8 +277,8 @@ fn visit_input_value<'a, Visitor, UserContext>(
             for (sub_key, sub_value) in v.iter() {
                 let input_type = context
                     .current_input_type_literal()
-                    .and_then(|v| context.schema.type_by_name(&v.inner_type()))
-                    .and_then(|v| v.input_field_by_name(&sub_key))
+                    .and_then(|v| context.schema.type_by_name(v.inner_type()))
+                    .and_then(|v| v.input_field_by_name(sub_key))
                     .and_then(|v| Some(&v.value_type));
 
                 context.with_input_type(input_type, |context| {
@@ -311,7 +311,7 @@ fn visit_variable_definitions<'a, Visitor, UserContext>(
             visitor.enter_variable_definition(context, user_context, variable);
 
             if let Some(default_value) = &variable.default_value {
-                visit_input_value(visitor, &default_value, context, user_context);
+                visit_input_value(visitor, default_value, context, user_context);
             }
 
             // DOTAN: We should visit the directives as well here, but it's extracted in graphql_parser.
@@ -335,7 +335,7 @@ fn visit_selection<'a, Visitor, UserContext>(
                 .current_parent_type()
                 .and_then(|t| t.field_by_name(&field.name));
 
-            let field_type = parent_type_def.clone().map(|f| &f.field_type);
+            let field_type = parent_type_def.map(|f| &f.field_type);
             let field_args = parent_type_def.map(|f| &f.arguments);
 
             context.with_type(field_type, |context| {

--- a/src/ast/operation_visitor.rs
+++ b/src/ast/operation_visitor.rs
@@ -278,8 +278,7 @@ fn visit_input_value<'a, Visitor, UserContext>(
                 let input_type = context
                     .current_input_type_literal()
                     .and_then(|v| context.schema.type_by_name(v.inner_type()))
-                    .and_then(|v| v.input_field_by_name(sub_key))
-                    .and_then(|v| Some(&v.value_type));
+                    .and_then(|v| v.input_field_by_name(sub_key)).map(|v| &v.value_type);
 
                 context.with_input_type(input_type, |context| {
                     let param = &(sub_key.clone(), sub_value.clone());

--- a/src/ast/schema_visitor.rs
+++ b/src/ast/schema_visitor.rs
@@ -174,7 +174,7 @@ pub trait SchemaVisitor<T = ()> {
 
 #[test]
 fn visit_schema() {
-    use graphql_parser::schema::parse_schema;
+    use crate::parser::schema::parse_schema;
     let schema_ast = parse_schema(
         r#"
     scalar Date

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod static_graphql {
     macro_rules! static_graphql {
     ($m:ident, $m2:ident, {$($n:ident,)*}) => {
         pub mod $m {
-            use graphql_parser::$m2 as $m;
+            use crate::parser::$m2 as $m;
             pub use $m::*;
             $(
                 pub type $n = $m::$n<'static, String>;
@@ -35,3 +35,8 @@ pub mod static_graphql {
 pub mod introspection;
 
 pub mod validation;
+
+#[cfg(feature = "graphql_parser")]
+pub extern crate graphql_parser as parser;
+#[cfg(feature = "graphql_parser_fork")]
+pub extern crate graphql_parser_hive_fork as parser;

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -13,6 +13,12 @@ use super::ValidationRule;
 /// See https://spec.graphql.org/draft/#sec-Field-Selections
 pub struct FieldsOnCorrectType;
 
+impl Default for FieldsOnCorrectType {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FieldsOnCorrectType {
     pub fn new() -> Self {
         FieldsOnCorrectType
@@ -56,7 +62,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for FieldsOnCorrectType {
                 return;
             }
 
-            if let None = parent_type.field_by_name(field_name) {
+            if parent_type.field_by_name(field_name).is_none() {
                 user_context.report_error(ValidationError {
                     error_code: self.error_code(),
                     locations: vec![field.position],
@@ -75,14 +81,14 @@ impl ValidationRule for FieldsOnCorrectType {
         "FieldsOnCorrectType"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut FieldsOnCorrectType::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/fields_on_correct_type.rs
+++ b/src/validation/rules/fields_on_correct_type.rs
@@ -130,7 +130,7 @@ fn object_field_selection() {
           __typename
           name
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -147,7 +147,7 @@ fn aliased_object_field_selection() {
           tn : __typename
           otherName : name
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -164,7 +164,7 @@ fn interface_field_selection() {
           __typename
           name
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -180,7 +180,7 @@ fn aliased_interface_field_selection() {
         "fragment interfaceFieldSelection on Pet {
           otherName : name
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -196,7 +196,7 @@ fn lying_alias_selection() {
         "fragment lyingAliasSelection on Dog {
           name : nickname
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -212,7 +212,7 @@ fn ignores_fields_on_unknown_type() {
         "fragment unknownSelection on UnknownType {
           unknownField
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -232,7 +232,7 @@ fn reports_errors_when_type_is_known_again() {
             }
           }
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -256,7 +256,7 @@ fn field_not_defined_on_fragment() {
         "fragment fieldNotDefined on Dog {
           meowVolume
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -279,7 +279,7 @@ fn ignores_deeply_unknown_field() {
             deeper_unknown_field
           }
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -302,7 +302,7 @@ fn sub_field_not_defined() {
             unknown_field
           }
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -325,7 +325,7 @@ fn field_not_defined_on_inline_fragment() {
             meowVolume
           }
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -346,7 +346,7 @@ fn aliased_field_target_not_defined() {
         "fragment aliasedFieldTargetNotDefined on Dog {
           volume : mooVolume
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -367,7 +367,7 @@ fn aliased_lying_field_target_not_defined() {
         "fragment aliasedLyingFieldTargetNotDefined on Dog {
           barkVolume : kawVolume
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -388,7 +388,7 @@ fn not_defined_on_interface() {
         "fragment notDefinedOnInterface on Pet {
           tailLength
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -409,7 +409,7 @@ fn defined_on_implementors_but_not_on_interface() {
         "fragment definedOnImplementorsButNotInterface on Pet {
           nickname
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -430,7 +430,7 @@ fn direct_field_selection_on_union() {
         "fragment directFieldSelectionOnUnion on CatOrDog {
           directField
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -451,7 +451,7 @@ fn defined_on_implementors_queried_on_union() {
         "fragment definedOnImplementorsQueriedOnUnion on CatOrDog {
           name
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -472,7 +472,7 @@ fn meta_field_selection_on_union() {
         "fragment directFieldSelectionOnUnion on CatOrDog {
           __typename
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -494,7 +494,7 @@ fn valid_field_in_inline_fragment() {
             name
           }
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 
@@ -511,7 +511,7 @@ fn forbidden_typename_on_subscription_type() {
         "subscription {
           __typename 
         }",
-        &FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
+        FIELDS_ON_CORRECT_TYPE_TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/fragments_on_composite_types.rs
+++ b/src/validation/rules/fragments_on_composite_types.rs
@@ -15,6 +15,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// https://spec.graphql.org/draft/#sec-Fragments-On-Composite-Types
 pub struct FragmentsOnCompositeTypes;
 
+impl Default for FragmentsOnCompositeTypes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FragmentsOnCompositeTypes {
     pub fn new() -> Self {
         FragmentsOnCompositeTypes
@@ -72,14 +78,14 @@ impl ValidationRule for FragmentsOnCompositeTypes {
         "FragmentsOnCompositeTypes"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut FragmentsOnCompositeTypes::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/known_argument_names.rs
+++ b/src/validation/rules/known_argument_names.rs
@@ -24,6 +24,12 @@ enum ArgumentParent<'a> {
     Directive(&'a str),
 }
 
+impl<'a> Default for KnownArgumentNames<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> KnownArgumentNames<'a> {
     pub fn new() -> Self {
         KnownArgumentNames {
@@ -128,14 +134,14 @@ impl<'k> ValidationRule for KnownArgumentNames<'k> {
         "KnownArgumentNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut KnownArgumentNames::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/known_argument_names.rs
+++ b/src/validation/rules/known_argument_names.rs
@@ -97,7 +97,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownArgumentNames<'a>
                 match arg_position {
                     ArgumentParent::Field(field_name, type_name) => {
                         user_context.report_error(ValidationError {
-                          error_code: self.error_code(),  
+                            error_code: self.error_code(),
                             message: format!(
                                 "Unknown argument \"{}\" on field \"{}.{}\".",
                                 argument_name,
@@ -109,7 +109,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownArgumentNames<'a>
                     }
                     ArgumentParent::Directive(directive_name) => {
                         user_context.report_error(ValidationError {
-                          error_code: self.error_code(),
+                            error_code: self.error_code(),
                             message: format!(
                                 "Unknown argument \"{}\" on directive \"@{}\".",
                                 argument_name, directive_name

--- a/src/validation/rules/known_argument_names.rs
+++ b/src/validation/rules/known_argument_names.rs
@@ -157,7 +157,7 @@ fn single_arg_is_known() {
         "fragment argOnRequiredArg on Dog {
           doesKnowCommand(dogCommand: SIT)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -173,7 +173,7 @@ fn multple_args_are_known() {
         "fragment multipleArgs on ComplicatedArgs {
           multipleReqs(req1: 1, req2: 2)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -189,7 +189,7 @@ fn ignores_args_of_unknown_fields() {
         "fragment argOnUnknownField on Dog {
           unknownField(unknownArg: SIT)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -205,7 +205,7 @@ fn multiple_args_in_reverse_order_are_known() {
         "fragment multipleArgsReverseOrder on ComplicatedArgs {
           multipleReqs(req2: 2, req1: 1)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -221,7 +221,7 @@ fn no_args_on_optional_arg() {
         "fragment noArgOnOptionalArg on Dog {
           isHouseTrained
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -246,7 +246,7 @@ fn args_are_known_deeply() {
             }
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -262,7 +262,7 @@ fn directive_args_are_known() {
         "{
           dog @skip(if: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -278,7 +278,7 @@ fn field_args_are_invalid() {
         "{
           dog @skip(unless: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -299,7 +299,7 @@ fn directive_without_args_is_valid() {
         " {
           dog @onField
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -316,7 +316,7 @@ fn arg_passed_to_directive_without_arg_is_reported() {
         " {
           dog @onField(if: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -338,7 +338,7 @@ fn misspelled_directive_args_are_reported() {
         "{
           dog @skip(iff: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -359,7 +359,7 @@ fn invalid_arg_name() {
         "fragment invalidArgName on Dog {
           doesKnowCommand(unknown: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -381,7 +381,7 @@ fn misspelled_arg_name_is_reported() {
         "fragment invalidArgName on Dog {
           doesKnowCommand(DogCommand: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -402,7 +402,7 @@ fn unknown_args_amongst_known_args() {
         "fragment oneGoodArgOneInvalidArg on Dog {
           doesKnowCommand(whoKnows: 1, dogCommand: SIT, unknown: true)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -435,7 +435,7 @@ fn unknown_args_deeply() {
             }
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/known_directives.rs
+++ b/src/validation/rules/known_directives.rs
@@ -16,6 +16,12 @@ pub struct KnownDirectives {
     recent_location: Option<DirectiveLocation>,
 }
 
+impl Default for KnownDirectives {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KnownDirectives {
     pub fn new() -> Self {
         KnownDirectives {
@@ -159,14 +165,14 @@ impl ValidationRule for KnownDirectives {
         "KnownDirectives"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut KnownDirectives::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/known_directives.rs
+++ b/src/validation/rules/known_directives.rs
@@ -133,7 +133,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownDirectives {
                     .iter()
                     .any(|l| l == current_location)
                 {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         locations: vec![directive.position],
                         message: format!(
                             "Directive \"@{}\" may not be used on {}",
@@ -144,7 +145,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownDirectives {
                 }
             }
         } else {
-            user_context.report_error(ValidationError {error_code: self.error_code(),
+            user_context.report_error(ValidationError {
+                error_code: self.error_code(),
                 locations: vec![directive.position],
                 message: format!("Unknown directive \"@{}\".", directive.name),
             });

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -11,6 +11,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// See https://spec.graphql.org/draft/#sec-Fragment-spread-target-defined
 pub struct KnownFragmentNames;
 
+impl Default for KnownFragmentNames {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KnownFragmentNames {
     pub fn new() -> Self {
         KnownFragmentNames
@@ -24,17 +30,13 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownFragmentNames {
         user_context: &mut ValidationErrorContext,
         fragment_spread: &FragmentSpread,
     ) {
-        match visitor_context
+        if visitor_context
             .known_fragments
-            .get(fragment_spread.fragment_name.as_str())
-        {
-            None => user_context.report_error(ValidationError {
-                error_code: self.error_code(),
-                locations: vec![fragment_spread.position],
-                message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),
-            }),
-            _ => {}
-        }
+            .get(fragment_spread.fragment_name.as_str()) == None { user_context.report_error(ValidationError {
+            error_code: self.error_code(),
+            locations: vec![fragment_spread.position],
+            message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),
+        }) }
     }
 }
 
@@ -43,14 +45,14 @@ impl ValidationRule for KnownFragmentNames {
         "KnownFragmentNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut KnownFragmentNames::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -28,7 +28,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownFragmentNames {
             .known_fragments
             .get(fragment_spread.fragment_name.as_str())
         {
-            None => user_context.report_error(ValidationError {error_code: self.error_code(),
+            None => user_context.report_error(ValidationError {
+                error_code: self.error_code(),
                 locations: vec![fragment_spread.position],
                 message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),
             }),

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -30,13 +30,16 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownFragmentNames {
         user_context: &mut ValidationErrorContext,
         fragment_spread: &FragmentSpread,
     ) {
-        if visitor_context
+        if !visitor_context
             .known_fragments
-            .get(fragment_spread.fragment_name.as_str()).is_none() { user_context.report_error(ValidationError {
-            error_code: self.error_code(),
-            locations: vec![fragment_spread.position],
-            message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),
-        }) }
+            .contains_key(fragment_spread.fragment_name.as_str())
+        {
+            user_context.report_error(ValidationError {
+                error_code: self.error_code(),
+                locations: vec![fragment_spread.position],
+                message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),
+            })
+        }
     }
 }
 

--- a/src/validation/rules/known_fragment_names.rs
+++ b/src/validation/rules/known_fragment_names.rs
@@ -32,7 +32,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownFragmentNames {
     ) {
         if visitor_context
             .known_fragments
-            .get(fragment_spread.fragment_name.as_str()) == None { user_context.report_error(ValidationError {
+            .get(fragment_spread.fragment_name.as_str()).is_none() { user_context.report_error(ValidationError {
             error_code: self.error_code(),
             locations: vec![fragment_spread.position],
             message: format!("Unknown fragment \"{}\".", fragment_spread.fragment_name),

--- a/src/validation/rules/known_type_names.rs
+++ b/src/validation/rules/known_type_names.rs
@@ -31,7 +31,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownTypeNames {
 
         if let None = visitor_context.schema.type_by_name(fragment_type_name) {
             if !fragment_type_name.starts_with("__") {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     locations: vec![fragment_definition.position],
                     message: format!("Unknown type \"{}\".", fragment_type_name),
                 });
@@ -48,7 +49,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownTypeNames {
         if let Some(TypeCondition::On(fragment_type_name)) = &inline_fragment.type_condition {
             if let None = visitor_context.schema.type_by_name(fragment_type_name) {
                 if !fragment_type_name.starts_with("__") {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         locations: vec![inline_fragment.position],
                         message: format!("Unknown type \"{}\".", fragment_type_name),
                     });
@@ -67,7 +69,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownTypeNames {
 
         if let None = visitor_context.schema.type_by_name(&base_type) {
             if !base_type.starts_with("__") {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     locations: vec![variable_definition.position],
                     message: format!("Unknown type \"{}\".", base_type),
                 });

--- a/src/validation/rules/known_type_names.rs
+++ b/src/validation/rules/known_type_names.rs
@@ -69,14 +69,12 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for KnownTypeNames {
     ) {
         let base_type = variable_definition.var_type.inner_type();
 
-        if let None = visitor_context.schema.type_by_name(base_type) {
-            if !base_type.starts_with("__") {
-                user_context.report_error(ValidationError {
-                    error_code: self.error_code(),
-                    locations: vec![variable_definition.position],
-                    message: format!("Unknown type \"{}\".", base_type),
-                });
-            }
+        if visitor_context.schema.type_by_name(base_type).is_none() && !base_type.starts_with("__") {
+            user_context.report_error(ValidationError {
+                error_code: self.error_code(),
+                locations: vec![variable_definition.position],
+                message: format!("Unknown type \"{}\".", base_type),
+            });
         }
     }
 }
@@ -119,7 +117,7 @@ fn known_type_names_are_valid() {
         fragment PetFields on Pet {
           name
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -143,7 +141,7 @@ fn unknown_type_names_are_invalid() {
         fragment PetFields on Peat {
           name
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/leaf_field_selections.rs
+++ b/src/validation/rules/leaf_field_selections.rs
@@ -11,6 +11,12 @@ use crate::{
 /// https://spec.graphql.org/draft/#sec-Leaf-Field-Selections
 pub struct LeafFieldSelections;
 
+impl Default for LeafFieldSelections {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LeafFieldSelections {
     pub fn new() -> Self {
         LeafFieldSelections
@@ -42,19 +48,17 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LeafFieldSelections {
               ),
                     });
                 }
-            } else {
-                if field_selection_count == 0 {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
-              locations: vec![field.position],
-              message: format!(
-                  "Field \"{}\" of type \"{}\" must have a selection of subfields. Did you mean \"{} {{ ... }}\"?",
-                  field.name,
-                  field_type_literal,
-                  field.name
-              ),
-          });
-                }
-            }
+            } else if field_selection_count == 0 {
+                      user_context.report_error(ValidationError {error_code: self.error_code(),
+                locations: vec![field.position],
+                message: format!(
+                    "Field \"{}\" of type \"{}\" must have a selection of subfields. Did you mean \"{} {{ ... }}\"?",
+                    field.name,
+                    field_type_literal,
+                    field.name
+                ),
+            });
+                  }
         }
     }
 }
@@ -64,14 +68,14 @@ impl ValidationRule for LeafFieldSelections {
         "LeafFieldSelections"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut LeafFieldSelections::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/leaf_field_selections.rs
+++ b/src/validation/rules/leaf_field_selections.rs
@@ -32,7 +32,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LeafFieldSelections {
 
             if field_type.is_leaf_type() {
                 if field_selection_count > 0 {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         locations: vec![field.position],
                         message: format!(
                   "Field \"{}\" must not have a selection since type \"{}\" has no subfields.",

--- a/src/validation/rules/lone_anonymous_operation.rs
+++ b/src/validation/rules/lone_anonymous_operation.rs
@@ -40,7 +40,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LoneAnonymousOperation
             match definition {
                 Definition::Operation(OperationDefinition::SelectionSet(_)) => {
                     if operations_count > 1 {
-                        user_context.report_error(ValidationError {error_code: self.error_code(),
+                        user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
                             locations: vec![],
@@ -49,7 +50,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LoneAnonymousOperation
                 }
                 Definition::Operation(OperationDefinition::Query(query)) => {
                     if query.name == None && operations_count > 1 {
-                        user_context.report_error(ValidationError {error_code: self.error_code(),
+                        user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
                             locations: vec![query.position.clone()],
@@ -58,7 +60,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LoneAnonymousOperation
                 }
                 Definition::Operation(OperationDefinition::Mutation(mutation)) => {
                     if mutation.name == None && operations_count > 1 {
-                        user_context.report_error(ValidationError {error_code: self.error_code(),
+                        user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
                             locations: vec![mutation.position.clone()],
@@ -67,7 +70,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LoneAnonymousOperation
                 }
                 Definition::Operation(OperationDefinition::Subscription(subscription)) => {
                     if subscription.name == None && operations_count > 1 {
-                        user_context.report_error(ValidationError {error_code: self.error_code(),
+                        user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
                             locations: vec![subscription.position.clone()],

--- a/src/validation/rules/lone_anonymous_operation.rs
+++ b/src/validation/rules/lone_anonymous_operation.rs
@@ -11,6 +11,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// https://spec.graphql.org/draft/#sec-Lone-Anonymous-Operation
 pub struct LoneAnonymousOperation;
 
+impl Default for LoneAnonymousOperation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LoneAnonymousOperation {
     pub fn new() -> Self {
         LoneAnonymousOperation
@@ -49,32 +55,32 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for LoneAnonymousOperation
                     }
                 }
                 Definition::Operation(OperationDefinition::Query(query)) => {
-                    if query.name == None && operations_count > 1 {
+                    if query.name.is_none() && operations_count > 1 {
                         user_context.report_error(ValidationError {
                             error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
-                            locations: vec![query.position.clone()],
+                            locations: vec![query.position],
                         })
                     }
                 }
                 Definition::Operation(OperationDefinition::Mutation(mutation)) => {
-                    if mutation.name == None && operations_count > 1 {
+                    if mutation.name.is_none() && operations_count > 1 {
                         user_context.report_error(ValidationError {
                             error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
-                            locations: vec![mutation.position.clone()],
+                            locations: vec![mutation.position],
                         })
                     }
                 }
                 Definition::Operation(OperationDefinition::Subscription(subscription)) => {
-                    if subscription.name == None && operations_count > 1 {
+                    if subscription.name.is_none() && operations_count > 1 {
                         user_context.report_error(ValidationError {
                             error_code: self.error_code(),
                             message: "This anonymous operation must be the only defined operation."
                                 .to_string(),
-                            locations: vec![subscription.position.clone()],
+                            locations: vec![subscription.position],
                         })
                     }
                 }
@@ -89,14 +95,14 @@ impl ValidationRule for LoneAnonymousOperation {
         "LoneAnonymousOperation"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut LoneAnonymousOperation::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/no_fragments_cycle.rs
+++ b/src/validation/rules/no_fragments_cycle.rs
@@ -15,6 +15,12 @@ pub struct NoFragmentsCycle {
     visited_fragments: HashSet<String>,
 }
 
+impl Default for NoFragmentsCycle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl NoFragmentsCycle {
     pub fn new() -> Self {
         Self {
@@ -41,7 +47,7 @@ impl NoFragmentsCycle {
 
         let spread_nodes = fragment.selection_set.get_recursive_fragment_spreads();
 
-        if spread_nodes.len() == 0 {
+        if spread_nodes.is_empty() {
             return;
         }
 
@@ -64,7 +70,7 @@ impl NoFragmentsCycle {
                     }
                 }
                 Some(cycle_index) => {
-                    let cycle_path = &spread_paths[cycle_index.clone()..];
+                    let cycle_path = &spread_paths[*cycle_index..];
                     let via_path = match cycle_path.len() {
                         0 => vec![],
                         _ => cycle_path[0..cycle_path.len() - 1]
@@ -75,7 +81,7 @@ impl NoFragmentsCycle {
 
                     error_context.report_error(ValidationError {
                         error_code: self.error_code(),
-                        locations: cycle_path.iter().map(|f| f.position.clone()).collect(),
+                        locations: cycle_path.iter().map(|f| f.position).collect(),
                         message: match via_path.len() {
                             0 => {
                                 format!("Cannot spread fragment \"{}\" within itself.", spread_name)
@@ -122,14 +128,14 @@ impl ValidationRule for NoFragmentsCycle {
         "NoFragmentsCycle"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut NoFragmentsCycle::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/no_fragments_cycle.rs
+++ b/src/validation/rules/no_fragments_cycle.rs
@@ -73,7 +73,8 @@ impl NoFragmentsCycle {
                             .collect::<Vec<String>>(),
                     };
 
-                    error_context.report_error(ValidationError {error_code: self.error_code(),
+                    error_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         locations: cycle_path.iter().map(|f| f.position.clone()).collect(),
                         message: match via_path.len() {
                             0 => {

--- a/src/validation/rules/no_undefined_variables.rs
+++ b/src/validation/rules/no_undefined_variables.rs
@@ -13,10 +13,10 @@ use std::collections::{HashMap, HashSet};
 ///
 /// See https://spec.graphql.org/draft/#sec-All-Variable-Uses-Defined
 pub struct NoUndefinedVariables<'a> {
-    current_scope: Option<Scope<'a>>,
+    current_scope: Option<NoUndefinedVariablesScope<'a>>,
     defined_variables: HashMap<Option<&'a str>, HashSet<&'a str>>,
-    used_variables: HashMap<Scope<'a>, Vec<&'a str>>,
-    spreads: HashMap<Scope<'a>, Vec<&'a str>>,
+    used_variables: HashMap<NoUndefinedVariablesScope<'a>, Vec<&'a str>>,
+    spreads: HashMap<NoUndefinedVariablesScope<'a>, Vec<&'a str>>,
 }
 
 impl<'a> NoUndefinedVariables<'a> {
@@ -33,10 +33,10 @@ impl<'a> NoUndefinedVariables<'a> {
 impl<'a> NoUndefinedVariables<'a> {
     fn find_undefined_vars(
         &self,
-        from: &Scope<'a>,
+        from: &NoUndefinedVariablesScope<'a>,
         defined: &HashSet<&str>,
         unused: &mut HashSet<&'a str>,
-        visited: &mut HashSet<Scope<'a>>,
+        visited: &mut HashSet<NoUndefinedVariablesScope<'a>>,
     ) {
         if visited.contains(from) {
             return;
@@ -54,14 +54,19 @@ impl<'a> NoUndefinedVariables<'a> {
 
         if let Some(spreads) = self.spreads.get(from) {
             for spread in spreads {
-                self.find_undefined_vars(&Scope::Fragment(spread), defined, unused, visited);
+                self.find_undefined_vars(
+                    &NoUndefinedVariablesScope::Fragment(spread),
+                    defined,
+                    unused,
+                    visited,
+                );
             }
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Scope<'a> {
+pub enum NoUndefinedVariablesScope<'a> {
     Operation(Option<&'a str>),
     Fragment(&'a str),
 }
@@ -74,7 +79,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUndefinedVariables<'
         operation_definition: &'a OperationDefinition,
     ) {
         let op_name = operation_definition.node_name();
-        self.current_scope = Some(Scope::Operation(op_name));
+        self.current_scope = Some(NoUndefinedVariablesScope::Operation(op_name));
         self.defined_variables.insert(op_name, HashSet::new());
     }
 
@@ -84,7 +89,9 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUndefinedVariables<'
         _: &mut ValidationErrorContext,
         fragment_definition: &'a query::FragmentDefinition,
     ) {
-        self.current_scope = Some(Scope::Fragment(&fragment_definition.name));
+        self.current_scope = Some(NoUndefinedVariablesScope::Fragment(
+            &fragment_definition.name,
+        ));
     }
 
     fn enter_fragment_spread(
@@ -107,7 +114,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUndefinedVariables<'
         _: &mut ValidationErrorContext,
         variable_definition: &'a query::VariableDefinition,
     ) {
-        if let Some(Scope::Operation(ref name)) = self.current_scope {
+        if let Some(NoUndefinedVariablesScope::Operation(ref name)) = self.current_scope {
             if let Some(vars) = self.defined_variables.get_mut(name) {
                 vars.insert(&variable_definition.name);
             }
@@ -139,14 +146,15 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUndefinedVariables<'
             let mut visited = HashSet::new();
 
             self.find_undefined_vars(
-                &Scope::Operation(op_name.clone()),
+                &NoUndefinedVariablesScope::Operation(op_name.clone()),
                 def_vars,
                 &mut unused,
                 &mut visited,
             );
 
             unused.iter().for_each(|var| {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: error_message(&var, op_name),
                     locations: vec![],
                 })

--- a/src/validation/rules/no_unused_fragments.rs
+++ b/src/validation/rules/no_unused_fragments.rs
@@ -34,7 +34,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments<'a> 
             .known_fragments
             .iter()
             .filter_map(|(fragment_name, _fragment)| {
-                if !self.fragments_in_use.contains(&fragment_name) {
+                if !self.fragments_in_use.contains(fragment_name) {
                     Some(fragment_name)
                 } else {
                     None
@@ -47,6 +47,12 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments<'a> 
                     message: format!("Fragment \"{}\" is never used.", unused_fragment_name),
                 });
             });
+    }
+}
+
+impl<'a> Default for NoUnusedFragments<'a> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -63,14 +69,14 @@ impl<'n> ValidationRule for NoUnusedFragments<'n> {
         "NoUnusedFragments"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut NoUnusedFragments::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/no_unused_fragments.rs
+++ b/src/validation/rules/no_unused_fragments.rs
@@ -35,13 +35,14 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedFragments<'a> 
             .iter()
             .filter_map(|(fragment_name, _fragment)| {
                 if !self.fragments_in_use.contains(&fragment_name) {
-                    Some(fragment_name.clone())
+                    Some(fragment_name)
                 } else {
                     None
                 }
             })
             .for_each(|unused_fragment_name| {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     locations: vec![],
                     message: format!("Fragment \"{}\" is never used.", unused_fragment_name),
                 });

--- a/src/validation/rules/no_unused_variables.rs
+++ b/src/validation/rules/no_unused_variables.rs
@@ -14,10 +14,10 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 ///
 /// See https://spec.graphql.org/draft/#sec-All-Variables-Used
 pub struct NoUnusedVariables<'a> {
-    current_scope: Option<Scope<'a>>,
+    current_scope: Option<NoUnusedVariablesScope<'a>>,
     defined_variables: HashMap<Option<&'a str>, HashSet<&'a str>>,
-    used_variables: HashMap<Scope<'a>, Vec<&'a str>>,
-    spreads: HashMap<Scope<'a>, Vec<&'a str>>,
+    used_variables: HashMap<NoUnusedVariablesScope<'a>, Vec<&'a str>>,
+    spreads: HashMap<NoUnusedVariablesScope<'a>, Vec<&'a str>>,
 }
 
 impl<'a> NoUnusedVariables<'a> {
@@ -34,10 +34,10 @@ impl<'a> NoUnusedVariables<'a> {
 impl<'a> NoUnusedVariables<'a> {
     fn find_used_vars(
         &self,
-        from: &Scope<'a>,
+        from: &NoUnusedVariablesScope<'a>,
         defined: &HashSet<&str>,
         used: &mut HashSet<&'a str>,
-        visited: &mut HashSet<Scope<'a>>,
+        visited: &mut HashSet<NoUnusedVariablesScope<'a>>,
     ) {
         if visited.contains(from) {
             return;
@@ -55,14 +55,19 @@ impl<'a> NoUnusedVariables<'a> {
 
         if let Some(spreads) = self.spreads.get(from) {
             for spread in spreads {
-                self.find_used_vars(&Scope::Fragment(spread), defined, used, visited);
+                self.find_used_vars(
+                    &NoUnusedVariablesScope::Fragment(spread),
+                    defined,
+                    used,
+                    visited,
+                );
             }
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Scope<'a> {
+pub enum NoUnusedVariablesScope<'a> {
     Operation(Option<&'a str>),
     Fragment(&'a str),
 }
@@ -75,7 +80,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedVariables<'a> 
         operation_definition: &'a OperationDefinition,
     ) {
         let op_name = operation_definition.node_name();
-        self.current_scope = Some(Scope::Operation(op_name));
+        self.current_scope = Some(NoUnusedVariablesScope::Operation(op_name));
         self.defined_variables.insert(op_name, HashSet::new());
     }
 
@@ -85,7 +90,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedVariables<'a> 
         _: &mut ValidationErrorContext,
         fragment_definition: &'a query::FragmentDefinition,
     ) {
-        self.current_scope = Some(Scope::Fragment(&fragment_definition.name));
+        self.current_scope = Some(NoUnusedVariablesScope::Fragment(&fragment_definition.name));
     }
 
     fn enter_fragment_spread(
@@ -108,7 +113,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedVariables<'a> 
         _: &mut ValidationErrorContext,
         variable_definition: &'a query::VariableDefinition,
     ) {
-        if let Some(Scope::Operation(ref name)) = self.current_scope {
+        if let Some(NoUnusedVariablesScope::Operation(ref name)) = self.current_scope {
             if let Some(vars) = self.defined_variables.get_mut(name) {
                 vars.insert(&variable_definition.name);
             }
@@ -140,7 +145,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedVariables<'a> 
             let mut visited = HashSet::new();
 
             self.find_used_vars(
-                &Scope::Operation(op_name.clone()),
+                &NoUnusedVariablesScope::Operation(op_name.clone()),
                 &def_vars,
                 &mut used,
                 &mut visited,
@@ -150,7 +155,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for NoUnusedVariables<'a> 
                 .iter()
                 .filter(|var| !used.contains(*var))
                 .for_each(|var| {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         message: error_message(var, op_name),
                         locations: vec![],
                     })

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -794,9 +794,8 @@ impl<'a> OverlappingFieldsCanBeMerged<'a> {
                         .push(AstAndDef(parent_type, field, field_def));
                 }
                 Selection::FragmentSpread(fragment_spread) => {
-                    if fragment_names
-                        .iter()
-                        .find(|n| (*n).eq(&fragment_spread.fragment_name)).is_none()
+                    if !fragment_names
+                        .iter().any(|n| (*n).eq(&fragment_spread.fragment_name))
                     {
                         fragment_names.push(&fragment_spread.fragment_name);
                     }

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -779,7 +779,7 @@ impl<'a> OverlappingFieldsCanBeMerged<'a> {
                     let out_field_name = field.alias.as_ref().unwrap_or(field_name).as_str();
 
                     if !ast_and_defs.contains_key(out_field_name) {
-                        ast_and_defs.insert(out_field_name.clone(), Vec::new());
+                        ast_and_defs.insert(out_field_name, Vec::new());
                     }
 
                     ast_and_defs
@@ -852,7 +852,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for OverlappingFieldsCanBe
         for Conflict(ConflictReason(reason_name, reason_msg), mut p1, p2) in found_conflicts {
             p1.extend(p2);
 
-            user_context.report_error(ValidationError {error_code: self.error_code(),
+            user_context.report_error(ValidationError {
+                error_code: self.error_code(),
                 message: error_message(&reason_name, &reason_msg),
                 locations: p1,
             });

--- a/src/validation/rules/overlapping_fields_can_be_merged.rs
+++ b/src/validation/rules/overlapping_fields_can_be_merged.rs
@@ -1,5 +1,5 @@
-use graphql_parser::query::{Definition, TypeCondition};
-use graphql_parser::Pos;
+use crate::parser::query::{Definition, TypeCondition};
+use crate::parser::Pos;
 
 use super::ValidationRule;
 use crate::ast::ext::TypeDefinitionExtension;

--- a/src/validation/rules/possible_fragment_spreads.rs
+++ b/src/validation/rules/possible_fragment_spreads.rs
@@ -17,6 +17,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// https://spec.graphql.org/draft/#sec-Fragment-spread-is-possible
 pub struct PossibleFragmentSpreads;
 
+impl Default for PossibleFragmentSpreads {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PossibleFragmentSpreads {
     pub fn new() -> Self {
         Self {}
@@ -73,7 +79,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for PossibleFragmentSpread
             if let Some(parent_type) = visitor_context.current_parent_type() {
                 if frag_schema_type.is_composite_type()
                     && parent_type.is_composite_type()
-                    && !do_types_overlap(&visitor_context.schema, frag_schema_type, &parent_type)
+                    && !do_types_overlap(visitor_context.schema, frag_schema_type, parent_type)
                 {
                     user_context.report_error(ValidationError {error_code: self.error_code(),
                       locations: vec![],
@@ -100,7 +106,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for PossibleFragmentSpread
                 if let Some(parent_type) = visitor_context.current_parent_type() {
                     if fragment_type.is_composite_type()
                         && parent_type.is_composite_type()
-                        && !do_types_overlap(&visitor_context.schema, &fragment_type, &parent_type)
+                        && !do_types_overlap(visitor_context.schema, fragment_type, parent_type)
                     {
                         user_context.report_error(ValidationError {error_code: self.error_code(),
                         locations: vec![],
@@ -118,14 +124,14 @@ impl ValidationRule for PossibleFragmentSpreads {
         "PossibleFragmentSpreads"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut PossibleFragmentSpreads::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/provided_required_arguments.rs
+++ b/src/validation/rules/provided_required_arguments.rs
@@ -122,7 +122,7 @@ fn ignores_unknown_arguments() {
             isHouseTrained(unknownArgument: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -140,7 +140,7 @@ fn arg_on_optional_arg() {
             isHouseTrained(atOtherHomes: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -158,7 +158,7 @@ fn no_arg_on_optional_arg() {
             isHouseTrained
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -176,7 +176,7 @@ fn multiple_args() {
             multipleReqs(req1: 1, req2: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -194,7 +194,7 @@ fn multiple_args_reverse_order() {
             multipleReqs(req2: 2, req1: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -212,7 +212,7 @@ fn no_args_on_multiple_optional() {
             multipleOpts
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -230,7 +230,7 @@ fn one_arg_on_multiple_optional() {
             multipleOpts(opt1: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -248,7 +248,7 @@ fn second_arg_on_multiple_optional() {
             multipleOpts(opt2: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -266,7 +266,7 @@ fn multiple_required_args_on_mixed_list() {
             multipleOptAndReq(req1: 3, req2: 4)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -284,7 +284,7 @@ fn multiple_required_and_one_optional_arg_on_mixedlist() {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -302,7 +302,7 @@ fn all_required_and_optional_args_on_mixedlist() {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -320,7 +320,7 @@ fn missing_one_non_nullable_argument() {
             multipleReqs(req2: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -342,7 +342,7 @@ fn missing_multiple_non_nullable_arguments() {
             multipleReqs
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -365,7 +365,7 @@ fn incorrect_value_and_missing_argument() {
             multipleReqs(req1: \"one\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -385,7 +385,7 @@ fn ignores_unknown_directives() {
         "{
           dog @unknown
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -407,7 +407,7 @@ fn with_directives_of_valid_types() {
             name
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -426,7 +426,7 @@ fn with_directive_with_missing_types() {
             name @skip
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/provided_required_arguments.rs
+++ b/src/validation/rules/provided_required_arguments.rs
@@ -73,16 +73,17 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ProvidedRequiredArgume
     }
 }
 
-fn validate_arguments<'a>(
-    arguments_used: &Vec<(String, Value)>,
-    arguments_defined: &Vec<InputValue>,
+fn validate_arguments(
+    arguments_used: &[(String, Value)],
+    arguments_defined: &[InputValue],
 ) -> Vec<InputValue> {
     arguments_defined
         .iter()
         .filter_map(|field_arg_def| {
             if field_arg_def.is_required()
                 && !arguments_used
-                    .iter().any(|(name, _value)| name.eq(&field_arg_def.name))
+                    .iter()
+                    .any(|(name, _value)| name.eq(&field_arg_def.name))
             {
                 Some(field_arg_def.clone())
             } else {

--- a/src/validation/rules/provided_required_arguments.rs
+++ b/src/validation/rules/provided_required_arguments.rs
@@ -15,6 +15,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// See https://spec.graphql.org/draft/#sec-Required-Arguments
 pub struct ProvidedRequiredArguments;
 
+impl Default for ProvidedRequiredArguments {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ProvidedRequiredArguments {
     pub fn new() -> Self {
         ProvidedRequiredArguments
@@ -72,13 +78,11 @@ fn validate_arguments<'a>(
     arguments_defined: &Vec<InputValue>,
 ) -> Vec<InputValue> {
     arguments_defined
-        .into_iter()
+        .iter()
         .filter_map(|field_arg_def| {
             if field_arg_def.is_required()
-                && arguments_used
-                    .iter()
-                    .find(|(name, _value)| name.eq(&field_arg_def.name))
-                    .is_none()
+                && !arguments_used
+                    .iter().any(|(name, _value)| name.eq(&field_arg_def.name))
             {
                 Some(field_arg_def.clone())
             } else {
@@ -93,14 +97,14 @@ impl ValidationRule for ProvidedRequiredArguments {
         "ProvidedRequiredArguments"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut ProvidedRequiredArguments::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/rule.rs
+++ b/src/validation/rules/rule.rs
@@ -1,11 +1,11 @@
 use crate::{ast::OperationVisitorContext, validation::utils::ValidationErrorContext};
 
 pub trait ValidationRule: Send + Sync {
-    fn validate<'a>(
+    fn validate(
         &self,
-        _ctx: &mut OperationVisitorContext<'a>,
+        _ctx: &mut OperationVisitorContext<'_>,
         _error_collector: &mut ValidationErrorContext,
-    ) -> ();
+    );
 
     fn error_code<'a>(&self) -> &'a str;
 }

--- a/src/validation/rules/single_field_subscriptions.rs
+++ b/src/validation/rules/single_field_subscriptions.rs
@@ -49,7 +49,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for SingleFieldSubscriptio
                                 .to_owned(),
                         };
 
-                        user_context.report_error(ValidationError {error_code: self.error_code(),
+                        user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             locations: vec![subscription.position],
                             message: error_message,
                         });

--- a/src/validation/rules/single_field_subscriptions.rs
+++ b/src/validation/rules/single_field_subscriptions.rs
@@ -14,6 +14,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// See https://spec.graphql.org/draft/#sec-Operation-Name-Uniqueness
 pub struct SingleFieldSubscriptions;
 
+impl Default for SingleFieldSubscriptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SingleFieldSubscriptions {
     pub fn new() -> Self {
         Self
@@ -27,62 +33,59 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for SingleFieldSubscriptio
         user_context: &mut ValidationErrorContext,
         operation: &OperationDefinition,
     ) {
-        match operation {
-            OperationDefinition::Subscription(subscription) => {
-                if let Some(subscription_type) = visitor_context.schema.subscription_type() {
-                    let operation_name = subscription.name.as_ref();
+        if let OperationDefinition::Subscription(subscription) = operation {
+            if let Some(subscription_type) = visitor_context.schema.subscription_type() {
+                let operation_name = subscription.name.as_ref();
 
-                    let selection_set_fields = collect_fields(
-                        &subscription.selection_set,
-                        &TypeDefinition::Object(subscription_type.clone()),
-                        &visitor_context.known_fragments,
-                        visitor_context,
-                    );
+                let selection_set_fields = collect_fields(
+                    &subscription.selection_set,
+                    &TypeDefinition::Object(subscription_type.clone()),
+                    &visitor_context.known_fragments,
+                    visitor_context,
+                );
 
-                    if selection_set_fields.len() > 1 {
-                        let error_message = match operation_name {
-                            Some(operation_name) => format!(
-                                "Subscription \"{}\" must select only one top level field.",
-                                operation_name
-                            ),
-                            None => "Anonymous Subscription must select only one top level field."
-                                .to_owned(),
-                        };
+                if selection_set_fields.len() > 1 {
+                    let error_message = match operation_name {
+                        Some(operation_name) => format!(
+                            "Subscription \"{}\" must select only one top level field.",
+                            operation_name
+                        ),
+                        None => "Anonymous Subscription must select only one top level field."
+                            .to_owned(),
+                    };
 
-                        user_context.report_error(ValidationError {
-                            error_code: self.error_code(),
-                            locations: vec![subscription.position],
-                            message: error_message,
-                        });
-                    }
-
-                    selection_set_fields
-                  .into_iter()
-                  .filter_map(|(field_name, fields_records)| {
-                      if field_name.starts_with("__") {
-                          return Some((field_name, fields_records));
-                      }
-
-                      None
-                  })
-                  .for_each(|(_field_name, _fields_records)| {
-                      let error_message = match operation_name {
-                          Some(operation_name) => format!(
-                              "Subscription \"{}\" must not select an introspection top level field.",
-                              operation_name
-                          ),
-                          None => "Anonymous Subscription must not select an introspection top level field."
-                              .to_owned(),
-                      };
-
-                      user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         locations: vec![subscription.position],
                         message: error_message,
                     });
-                  })
                 }
+
+                selection_set_fields
+              .into_iter()
+              .filter_map(|(field_name, fields_records)| {
+                  if field_name.starts_with("__") {
+                      return Some((field_name, fields_records));
+                  }
+
+                  None
+              })
+              .for_each(|(_field_name, _fields_records)| {
+                  let error_message = match operation_name {
+                      Some(operation_name) => format!(
+                          "Subscription \"{}\" must not select an introspection top level field.",
+                          operation_name
+                      ),
+                      None => "Anonymous Subscription must not select an introspection top level field."
+                          .to_owned(),
+                  };
+
+                  user_context.report_error(ValidationError {error_code: self.error_code(),
+                    locations: vec![subscription.position],
+                    message: error_message,
+                });
+              })
             }
-            _ => {}
         }
     }
 }
@@ -92,14 +95,14 @@ impl ValidationRule for SingleFieldSubscriptions {
         "SingleFieldSubscriptions"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut SingleFieldSubscriptions::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/unique_argument_names.rs
+++ b/src/validation/rules/unique_argument_names.rs
@@ -15,6 +15,12 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// See https://spec.graphql.org/draft/#sec-Argument-Names
 pub struct UniqueArgumentNames;
 
+impl Default for UniqueArgumentNames {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UniqueArgumentNames {
     pub fn new() -> Self {
         UniqueArgumentNames
@@ -70,7 +76,7 @@ fn collect_from_arguments(
     for (arg_name, _arg_value) in arguments {
         found_args
             .entry(arg_name.clone())
-            .or_insert(vec![])
+            .or_default()
             .push(reported_position);
     }
 
@@ -82,14 +88,14 @@ impl ValidationRule for UniqueArgumentNames {
         "UniqueArgumentNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut UniqueArgumentNames::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/unique_argument_names.rs
+++ b/src/validation/rules/unique_argument_names.rs
@@ -32,7 +32,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueArgumentNames {
 
         found_args.iter().for_each(|(arg_name, positions)| {
             if positions.len() > 1 {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!("There can be only one argument named \"{}\".", arg_name),
                     locations: positions.clone(),
                 })
@@ -50,7 +51,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueArgumentNames {
 
         found_args.iter().for_each(|(arg_name, positions)| {
             if positions.len() > 1 {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!("There can be only one argument named \"{}\".", arg_name),
                     locations: positions.clone(),
                 })

--- a/src/validation/rules/unique_argument_names.rs
+++ b/src/validation/rules/unique_argument_names.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use graphql_parser::Pos;
+use crate::parser::Pos;
 
 use super::ValidationRule;
 use crate::ast::{visit_document, OperationVisitor, OperationVisitorContext};

--- a/src/validation/rules/unique_directives_per_location.rs
+++ b/src/validation/rules/unique_directives_per_location.rs
@@ -35,7 +35,8 @@ impl UniqueDirectivesPerLocation {
             if let Some(meta_directive) = ctx.directives.get(&directive.name) {
                 if !meta_directive.repeatable {
                     if exists.contains(&directive.name) {
-                        err_context.report_error(ValidationError {error_code: self.error_code(),
+                        err_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             locations: vec![directive.position],
                             message: format!("Duplicate directive \"{}\"", &directive.name),
                         });

--- a/src/validation/rules/unique_directives_per_location.rs
+++ b/src/validation/rules/unique_directives_per_location.rs
@@ -132,7 +132,7 @@ fn no_directives() {
         "fragment Test on Type {
             field
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -148,7 +148,7 @@ fn unique_directives_in_different_locations() {
         "fragment Test on Type @directiveA {
             field @directiveB
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -164,7 +164,7 @@ fn unique_directives_in_same_location() {
         "fragment Test on Type @directiveA @directiveB {
             field @directiveA @directiveB
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -180,7 +180,7 @@ fn same_directives_in_different_locations() {
         "fragment Test on Type @directiveA {
             field @directiveA
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -197,7 +197,7 @@ fn same_directives_in_similar_locations() {
             field @directive
             field @directive
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -213,7 +213,7 @@ fn repeatable_directives_in_same_location() {
         "fragment Test on Type @repeatable @repeatable {
             field @repeatable @repeatable
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -229,7 +229,7 @@ fn unknown_directives_must_be_ignored() {
         "fragment Test on Type @repeatable @repeatable {
             field @repeatable @repeatable
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -245,7 +245,7 @@ fn duplicate_directives_in_one_location() {
         "fragment Test on Type {
             field @onField @onField
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
     let messages = get_messages(&errors);
@@ -262,7 +262,7 @@ fn many_duplicate_directives_in_one_location() {
         "fragment Test on Type {
             field @onField @onField @onField
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
     let messages = get_messages(&errors);
@@ -285,7 +285,7 @@ fn different_duplicate_directives_in_one_location() {
         "fragment Test on Type {
             field @onField @testDirective @onField @testDirective
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
     let messages = get_messages(&errors);
@@ -308,7 +308,7 @@ fn duplicate_directives_in_many_location() {
         "fragment Test on Type @onFragmentDefinition @onFragmentDefinition {
             field @onField @onField
           }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
     let messages = get_messages(&errors);

--- a/src/validation/rules/unique_directives_per_location.rs
+++ b/src/validation/rules/unique_directives_per_location.rs
@@ -18,6 +18,12 @@ use crate::{
 /// See  https://spec.graphql.org/draft/#sec-Directives-Are-Unique-Per-Location
 pub struct UniqueDirectivesPerLocation {}
 
+impl Default for UniqueDirectivesPerLocation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl UniqueDirectivesPerLocation {
     pub fn new() -> Self {
         UniqueDirectivesPerLocation {}
@@ -103,14 +109,14 @@ impl ValidationRule for UniqueDirectivesPerLocation {
         "UniqueDirectivesPerLocation"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut UniqueDirectivesPerLocation::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/unique_fragment_names.rs
+++ b/src/validation/rules/unique_fragment_names.rs
@@ -36,7 +36,7 @@ impl<'a> UniqueFragmentNames<'a> {
 
     fn store_finding(&mut self, name: &'a str) {
         let value = *self.findings_counter.entry(name).or_insert(0);
-        self.findings_counter.insert(name.clone(), value + 1);
+        self.findings_counter.insert(name, value + 1);
     }
 }
 
@@ -58,7 +58,8 @@ impl<'u> ValidationRule for UniqueFragmentNames<'u> {
             .into_iter()
             .filter(|(_key, value)| *value > 1)
             .for_each(|(key, _value)| {
-                error_collector.report_error(ValidationError {error_code: self.error_code(),
+                error_collector.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!("There can be only one fragment named \"{}\".", key),
                     locations: vec![],
                 })

--- a/src/validation/rules/unique_fragment_names.rs
+++ b/src/validation/rules/unique_fragment_names.rs
@@ -22,8 +22,14 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueFragmentNames<'a
         fragment: &'a FragmentDefinition,
     ) {
         if let Some(name) = fragment.node_name() {
-            self.store_finding(&name);
+            self.store_finding(name);
         }
+    }
+}
+
+impl<'a> Default for UniqueFragmentNames<'a> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -45,14 +51,14 @@ impl<'u> ValidationRule for UniqueFragmentNames<'u> {
         "UniqueFragmentNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         let mut rule = UniqueFragmentNames::new();
 
-        visit_document(&mut rule, &ctx.operation, ctx, error_collector);
+        visit_document(&mut rule, ctx.operation, ctx, error_collector);
 
         rule.findings_counter
             .into_iter()

--- a/src/validation/rules/unique_operation_names.rs
+++ b/src/validation/rules/unique_operation_names.rs
@@ -45,9 +45,9 @@ impl<'u> ValidationRule for UniqueOperationNames<'u> {
         "UniqueOperationNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         let mut rule = UniqueOperationNames::new();

--- a/src/validation/rules/unique_operation_names.rs
+++ b/src/validation/rules/unique_operation_names.rs
@@ -27,6 +27,12 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueOperationNames<'
     }
 }
 
+impl<'a> Default for UniqueOperationNames<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> UniqueOperationNames<'a> {
     pub fn new() -> Self {
         Self {
@@ -52,7 +58,7 @@ impl<'u> ValidationRule for UniqueOperationNames<'u> {
     ) {
         let mut rule = UniqueOperationNames::new();
 
-        visit_document(&mut rule, &ctx.operation, ctx, error_collector);
+        visit_document(&mut rule, ctx.operation, ctx, error_collector);
 
         rule.findings_counter
             .into_iter()

--- a/src/validation/rules/unique_operation_names.rs
+++ b/src/validation/rules/unique_operation_names.rs
@@ -35,8 +35,8 @@ impl<'a> UniqueOperationNames<'a> {
     }
 
     fn store_finding(&mut self, name: &'a str) {
-        let value = *self.findings_counter.entry(name.clone()).or_insert(0);
-        self.findings_counter.insert(name.clone(), value + 1);
+        let value = *self.findings_counter.entry(name).or_insert(0);
+        self.findings_counter.insert(name, value + 1);
     }
 }
 
@@ -58,7 +58,8 @@ impl<'u> ValidationRule for UniqueOperationNames<'u> {
             .into_iter()
             .filter(|(_key, value)| *value > 1)
             .for_each(|(key, _value)| {
-                error_collector.report_error(ValidationError {error_code: self.error_code(),
+                error_collector.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!("There can be only one operation named \"{}\".", key),
                     locations: vec![],
                 })

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -13,6 +13,7 @@ use crate::validation::utils::{ValidationError, ValidationErrorContext};
 /// A GraphQL operation is only valid if all its variables are uniquely named.
 ///
 /// See https://spec.graphql.org/draft/#sec-Variable-Uniqueness
+#[derive(Default)]
 pub struct UniqueVariableNames<'a> {
     found_records: HashMap<&'a str, Pos>,
 }

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use graphql_parser::Pos;
+use crate::parser::Pos;
 
 use super::ValidationRule;
 use crate::ast::{visit_document, OperationVisitor, OperationVisitorContext};

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -63,14 +63,14 @@ impl<'v> ValidationRule for UniqueVariableNames<'v> {
         "UniqueVariableNames"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut UniqueVariableNames::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/unique_variable_names.rs
+++ b/src/validation/rules/unique_variable_names.rs
@@ -41,10 +41,10 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for UniqueVariableNames<'a
         user_context: &mut ValidationErrorContext,
         variable_definition: &'a VariableDefinition,
     ) {
-      let error_code = self.error_code();
+        let error_code = self.error_code();
         match self.found_records.entry(&variable_definition.name) {
             Entry::Occupied(entry) => user_context.report_error(ValidationError {
-              error_code,
+                error_code,
                 locations: vec![*entry.get(), variable_definition.position],
                 message: format!(
                     "There can only be one variable named \"${}\".",

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use graphql_parser::schema::TypeDefinition;
+use crate::parser::schema::TypeDefinition;
 
 use crate::ast::{
     InputValueHelpers, SchemaDocumentExtension, TypeDefinitionExtension, TypeExtension,

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -16,6 +16,12 @@ use super::ValidationRule;
 
 pub struct ValuesOfCorrectType {}
 
+impl Default for ValuesOfCorrectType {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ValuesOfCorrectType {
     pub fn new() -> Self {
         Self {}
@@ -37,7 +43,7 @@ impl ValuesOfCorrectType {
         if let Some(input_type) = visitor_context.current_input_type_literal() {
             let named_type = input_type.inner_type();
 
-            if let Some(type_def) = visitor_context.schema.type_by_name(&named_type) {
+            if let Some(type_def) = visitor_context.schema.type_by_name(named_type) {
                 if !type_def.is_leaf_type() {
                     user_context.report_error(ValidationError {
                         error_code: self.error_code(),
@@ -78,11 +84,9 @@ impl ValuesOfCorrectType {
                 if let TypeDefinition::Enum(enum_type_def) = &type_def {
                     match raw_value {
                         Value::Enum(enum_value) => {
-                            if enum_type_def
+                            if !enum_type_def
                                 .values
-                                .iter()
-                                .find(|v| v.name.eq(enum_value))
-                                .is_none()
+                                .iter().any(|v| v.name.eq(enum_value))
                             {
                                 user_context.report_error(ValidationError {
                                     error_code: self.error_code(),
@@ -150,11 +154,9 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
             });
 
             object_value.keys().for_each(|field_name| {
-                if (input_object_def
+                if !input_object_def
                     .fields
-                    .iter()
-                    .find(|f| f.name.eq(field_name)))
-                .is_none()
+                    .iter().any(|f| f.name.eq(field_name))
                 {
                     user_context.report_error(ValidationError {
                         error_code: self.error_code(),

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -39,7 +39,8 @@ impl ValuesOfCorrectType {
 
             if let Some(type_def) = visitor_context.schema.type_by_name(&named_type) {
                 if !type_def.is_leaf_type() {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         message: format!(
                             "Expected value of type \"{}\", found {}.",
                             named_type, raw_value
@@ -62,7 +63,8 @@ impl ValuesOfCorrectType {
                                 return;
                             }
 
-                            user_context.report_error(ValidationError {error_code: self.error_code(),
+                            user_context.report_error(ValidationError {
+                                error_code: self.error_code(),
                                 message: format!(
                                     "Expected value of type \"{}\", found {}.",
                                     expected, value
@@ -82,7 +84,8 @@ impl ValuesOfCorrectType {
                                 .find(|v| v.name.eq(enum_value))
                                 .is_none()
                             {
-                                user_context.report_error(ValidationError {error_code: self.error_code(),
+                                user_context.report_error(ValidationError {
+                                    error_code: self.error_code(),
                                     message: format!(
                                         "Value \"{}\" does not exist in \"{}\" enum.",
                                         enum_value, enum_type_def.name
@@ -91,7 +94,8 @@ impl ValuesOfCorrectType {
                                 })
                             }
                         }
-                        value => user_context.report_error(ValidationError {error_code: self.error_code(),
+                        value => user_context.report_error(ValidationError {
+                            error_code: self.error_code(),
                             message: format!(
                                 "Enum \"{}\" cannot represent non-enum value: {}",
                                 enum_type_def.name, value
@@ -114,7 +118,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
     ) {
         if let Some(input_type) = visitor_context.current_input_type_literal() {
             if input_type.is_non_null() {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!("Expected value of type \"{}\", found null", input_type),
                     locations: vec![],
                 })
@@ -133,7 +138,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
         {
             input_object_def.fields.iter().for_each(|field| {
                 if field.is_required() && !object_value.contains_key(&field.name) {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         message: format!(
                             "Field \"{}.{}\" of required type \"{}\" was not provided.",
                             input_object_def.name, field.name, field.value_type
@@ -150,7 +156,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
                     .find(|f| f.name.eq(field_name)))
                 .is_none()
                 {
-                    user_context.report_error(ValidationError {error_code: self.error_code(),
+                    user_context.report_error(ValidationError {
+                        error_code: self.error_code(),
                         message: format!(
                             "Field \"{}\" is not defined by type \"{}\".",
                             field_name, input_object_def.name

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -28,10 +28,7 @@ impl ValuesOfCorrectType {
     }
 
     pub fn is_custom_scalar(&self, type_name: &str) -> bool {
-        match type_name {
-            "String" | "Int" | "Float" | "Boolean" | "ID" => false,
-            _ => true,
-        }
+        !matches!(type_name, "String" | "Int" | "Float" | "Boolean" | "ID")
     }
 
     pub fn validate_value(
@@ -84,10 +81,7 @@ impl ValuesOfCorrectType {
                 if let TypeDefinition::Enum(enum_type_def) = &type_def {
                     match raw_value {
                         Value::Enum(enum_value) => {
-                            if !enum_type_def
-                                .values
-                                .iter().any(|v| v.name.eq(enum_value))
-                            {
+                            if !enum_type_def.values.iter().any(|v| v.name.eq(enum_value)) {
                                 user_context.report_error(ValidationError {
                                     error_code: self.error_code(),
                                     message: format!(
@@ -156,7 +150,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
             object_value.keys().for_each(|field_name| {
                 if !input_object_def
                     .fields
-                    .iter().any(|f| f.name.eq(field_name))
+                    .iter()
+                    .any(|f| f.name.eq(field_name))
                 {
                     user_context.report_error(ValidationError {
                         error_code: self.error_code(),

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -143,11 +143,10 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for ValuesOfCorrectType {
             });
 
             object_value.keys().for_each(|field_name| {
-                if (input_object_def
+                if input_object_def
                     .fields
                     .iter()
-                    .find(|f| f.name.eq(field_name)))
-                .is_none()
+                    .any(|f| f.name.eq(field_name))
                 {
                     user_context.report_error(ValidationError {
                         error_code: self.error_code(),

--- a/src/validation/rules/values_of_correct_type.rs
+++ b/src/validation/rules/values_of_correct_type.rs
@@ -216,7 +216,7 @@ fn valid_int_value() {
             intArgField(intArg: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -236,7 +236,7 @@ fn valid_negative_int_value() {
             intArgField(intArg: -2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -256,7 +256,7 @@ fn valid_boolean_value() {
             booleanArgField(booleanArg: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -276,7 +276,7 @@ fn valid_string_value() {
             stringArgField(stringArg: \"foo\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -296,7 +296,7 @@ fn valid_float_value() {
             floatArgField(floatArg: 1.1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -316,7 +316,7 @@ fn valid_negative_float_value() {
             floatArgField(floatArg: -1.1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -336,7 +336,7 @@ fn valid_int_into_float_value() {
             floatArgField(floatArg: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -356,7 +356,7 @@ fn valid_int_into_id_value() {
             idArgField(idArg: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -376,7 +376,7 @@ fn valid_string_into_id_value() {
             idArgField(idArg: \"someIdString\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -396,7 +396,7 @@ fn valid_enum_value() {
             doesKnowCommand(dogCommand: SIT)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -416,7 +416,7 @@ fn enum_undefined_value() {
             enumArgField(enumArg: UNKNOWN)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -436,7 +436,7 @@ fn enum_null_value() {
             enumArgField(enumArg: NO_FUR)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -456,7 +456,7 @@ fn valid_null_into_nullable() {
             intArgField(intArg: null)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -470,7 +470,7 @@ fn valid_null_into_nullable() {
             name
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -490,7 +490,7 @@ fn invalid_int_into_string() {
             stringArgField(stringArg: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -514,7 +514,7 @@ fn invalid_float_into_string() {
             stringArgField(stringArg: 1.0)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -538,7 +538,7 @@ fn invalid_bool_into_string() {
             stringArgField(stringArg: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -562,7 +562,7 @@ fn unquoted_string_to_string() {
             stringArgField(stringArg: BAR)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -586,7 +586,7 @@ fn invalid_string_into_int() {
             intArgField(intArg: \"3\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -611,7 +611,7 @@ fn bigint_into_int() {
             intArgField(intArg: 829384293849283498239482938)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -635,7 +635,7 @@ fn unquoted_string_into_int() {
             intArgField(intArg: FOO)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -656,7 +656,7 @@ fn simple_float_into_int() {
             intArgField(intArg: 3.0)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -677,7 +677,7 @@ fn float_into_int() {
             intArgField(intArg: 3.333)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -701,7 +701,7 @@ fn string_into_float() {
             floatArgField(floatArg: \"3.333\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -725,7 +725,7 @@ fn boolean_into_float() {
             floatArgField(floatArg: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -749,7 +749,7 @@ fn unquoted_into_float() {
             floatArgField(floatArg: FOO)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -773,7 +773,7 @@ fn int_into_boolean() {
             booleanArgField(booleanArg: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -797,7 +797,7 @@ fn float_into_boolean() {
             booleanArgField(booleanArg: 2.0)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -821,7 +821,7 @@ fn string_into_boolean() {
             booleanArgField(booleanArg: \"true\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -845,7 +845,7 @@ fn unquoted_into_boolean() {
             booleanArgField(booleanArg: TRUE)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -869,7 +869,7 @@ fn float_into_id() {
             idArgField(idArg: 1.0)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -890,7 +890,7 @@ fn bool_into_id() {
             idArgField(idArg: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -911,7 +911,7 @@ fn unquoted_into_id() {
             idArgField(idArg: SOMETHING)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -935,7 +935,7 @@ fn int_into_enum() {
             doesKnowCommand(dogCommand: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -959,7 +959,7 @@ fn float_into_enum() {
             doesKnowCommand(dogCommand: 1.0)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -983,7 +983,7 @@ fn string_into_enum() {
             doesKnowCommand(dogCommand: \"SIT\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1007,7 +1007,7 @@ fn boolean_into_enum() {
             doesKnowCommand(dogCommand: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1031,7 +1031,7 @@ fn unknown_enum_value_into_enum() {
             doesKnowCommand(dogCommand: JUGGLE)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1055,7 +1055,7 @@ fn different_case_enum_value_into_enum() {
             doesKnowCommand(dogCommand: sit)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1079,7 +1079,7 @@ fn valid_list_value() {
             stringListArgField(stringListArg: [\"one\", null, \"two\"])
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1099,7 +1099,7 @@ fn valid_empty_list_value() {
             stringListArgField(stringListArg: [])
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1119,7 +1119,7 @@ fn valid_null_list_value() {
             stringListArgField(stringListArg: null)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1139,7 +1139,7 @@ fn valid_single_value_into_list_value() {
             stringListArgField(stringListArg: \"one\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1159,7 +1159,7 @@ fn incorrect_item_type() {
             stringListArgField(stringListArg: [\"one\", 2])
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1183,7 +1183,7 @@ fn single_value_of_incorrect_type() {
             stringListArgField(stringListArg: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1207,7 +1207,7 @@ fn arg_on_optional_arg() {
             isHouseTrained(atOtherHomes: true)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1227,7 +1227,7 @@ fn no_arg_on_optional_arg() {
             isHouseTrained
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1247,7 +1247,7 @@ fn multiple_valid_args() {
             multipleReqs(req1: 1, req2: 2)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1267,7 +1267,7 @@ fn multiple_valid_args_reverse_oreder() {
             multipleReqs(req2: 2, req1: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1287,7 +1287,7 @@ fn no_args_multiple_optional() {
             multipleOpts
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1307,7 +1307,7 @@ fn one_arg_multiple_optinals() {
             multipleOpts(opt1: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1327,7 +1327,7 @@ fn second_arg_multiple_optinals() {
             multipleOpts(opt2: 1)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1347,7 +1347,7 @@ fn multiple_required_args_on_mixed_list() {
             multipleOptAndReq(req1: 3, req2: 4)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1367,7 +1367,7 @@ fn multiple_required_args_and_one_optional_on_mixed_list() {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1387,7 +1387,7 @@ fn all_required_and_one_optional() {
             multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1407,7 +1407,7 @@ fn incorrect_value_type() {
             multipleReqs(req2: \"two\", req1: \"one\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1434,7 +1434,7 @@ fn incorrect_value_and_missing_argument() {
             multipleReqs(req1: \"one\")
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1458,7 +1458,7 @@ fn null_value() {
             multipleReqs(req1: null)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1482,7 +1482,7 @@ fn optional_arg_despite_required_field_in_type() {
             complexArgField
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1502,7 +1502,7 @@ fn partial_object_only_required() {
             complexArgField(complexArg: { requiredField: true })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1522,7 +1522,7 @@ fn partial_object_required_field_can_be_falsy() {
             complexArgField(complexArg: { requiredField: false })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1542,7 +1542,7 @@ fn partial_object_including_required() {
             complexArgField(complexArg: { requiredField: true, intField: 4 })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1568,7 +1568,7 @@ fn full_object() {
             })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1594,7 +1594,7 @@ fn full_object_with_fields_in_different_order() {
             })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1614,7 +1614,7 @@ fn partial_object_missing_required() {
             complexArgField(complexArg: { intField: 4 })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1643,7 +1643,7 @@ fn partial_object_invalid_field_type() {
             })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1670,7 +1670,7 @@ fn partial_object_null_to_non_null_field() {
             })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1697,7 +1697,7 @@ fn partial_object_unknown_field_arg() {
             })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1751,7 +1751,7 @@ fn with_directives_of_valid_types() {
             name
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1771,7 +1771,7 @@ fn with_directives_of_invalid_types() {
             name @skip(if: ENUM)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1801,7 +1801,7 @@ fn variables_with_valid_default_values() {
         ) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1823,7 +1823,7 @@ fn variables_with_valid_default_null_values() {
         ) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1845,7 +1845,7 @@ fn variables_with_invalid_default_null_values() {
         ) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1875,7 +1875,7 @@ fn variables_with_invalid_default_values() {
         ) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1903,7 +1903,7 @@ fn variables_with_complex_invalid_default_values() {
         ) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1928,7 +1928,7 @@ fn complex_variables_missing_required_field() {
         query MissingRequiredField($a: ComplexInput = {intField: 3}) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -1952,7 +1952,7 @@ fn list_variables_with_invalid_item() {
         query InvalidItem($a: [String] = [\"one\", 2]) {
           dog { name }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/variables_are_input_types.rs
+++ b/src/validation/rules/variables_are_input_types.rs
@@ -32,7 +32,8 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for VariablesAreInputTypes
             .type_by_name(&variable_definition.var_type.inner_type())
         {
             if !var_schema_type.is_input_type() {
-                user_context.report_error(ValidationError {error_code: self.error_code(),
+                user_context.report_error(ValidationError {
+                    error_code: self.error_code(),
                     message: format!(
                         "Variable \"${}\" cannot be non-input type \"{}\".",
                         variable_definition.name, variable_definition.var_type

--- a/src/validation/rules/variables_are_input_types.rs
+++ b/src/validation/rules/variables_are_input_types.rs
@@ -75,7 +75,7 @@ fn unknown_types_are_ignored() {
         query Foo($a: Unknown, $b: [[Unknown!]]!) {
           field(a: $a, b: $b)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -93,7 +93,7 @@ fn input_types_are_valid() {
         query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {
           field(a: $a, b: $b, c: $c)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -111,7 +111,7 @@ fn output_types_are_invalid() {
        query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {
         field(a: $a, b: $b, c: $c)
       }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/rules/variables_are_input_types.rs
+++ b/src/validation/rules/variables_are_input_types.rs
@@ -12,6 +12,7 @@ use crate::validation::utils::ValidationErrorContext;
 /// input types (scalar, enum, or input object).
 ///
 /// See https://spec.graphql.org/draft/#sec-Variables-Are-Input-Types
+#[derive(Default)]
 pub struct VariablesAreInputTypes;
 
 impl VariablesAreInputTypes {
@@ -29,7 +30,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for VariablesAreInputTypes
     ) {
         if let Some(var_schema_type) = context
             .schema
-            .type_by_name(&variable_definition.var_type.inner_type())
+            .type_by_name(variable_definition.var_type.inner_type())
         {
             if !var_schema_type.is_input_type() {
                 user_context.report_error(ValidationError {
@@ -50,14 +51,14 @@ impl ValidationRule for VariablesAreInputTypes {
         "VariablesAreInputTypes"
     }
 
-    fn validate<'a>(
+    fn validate(
         &self,
-        ctx: &'a mut OperationVisitorContext,
+        ctx: &mut OperationVisitorContext,
         error_collector: &mut ValidationErrorContext,
     ) {
         visit_document(
             &mut VariablesAreInputTypes::new(),
-            &ctx.operation,
+            ctx.operation,
             ctx,
             error_collector,
         );

--- a/src/validation/rules/variables_in_allowed_position.rs
+++ b/src/validation/rules/variables_in_allowed_position.rs
@@ -157,7 +157,7 @@ impl<'a> OperationVisitor<'a, ValidationErrorContext> for VariablesInAllowedPosi
         if let Some(ref scope) = self.current_scope {
             self.variable_defs
                 .entry(scope.clone())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(&variable_definition);
         }
     }

--- a/src/validation/rules/variables_in_allowed_position.rs
+++ b/src/validation/rules/variables_in_allowed_position.rs
@@ -211,7 +211,7 @@ fn boolean_to_boolean() {
             booleanArgField(booleanArg: $booleanArg)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -233,7 +233,7 @@ fn boolean_to_boolean_within_fragment() {
             ...booleanArgFrag
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -249,7 +249,7 @@ fn boolean_to_boolean_within_fragment() {
       fragment booleanArgFrag on ComplicatedArgs {
         booleanArgField(booleanArg: $booleanArg)
       }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -268,7 +268,7 @@ fn boolean_nonnull_to_boolean() {
             booleanArgField(booleanArg: $nonNullBooleanArg)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -287,7 +287,7 @@ fn string_list_to_string_list() {
             stringListArgField(stringListArg: $stringListVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -306,7 +306,7 @@ fn string_list_nonnull_to_string_list() {
             stringListArgField(stringListArg: $stringListVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -325,7 +325,7 @@ fn string_to_string_list_in_item_position() {
             stringListArgField(stringListArg: [$stringVar])
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -344,7 +344,7 @@ fn string_nonnull_to_string_list_in_item_position() {
             stringListArgField(stringListArg: [$stringVar])
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -363,7 +363,7 @@ fn complexinput_to_complexinput() {
             complexArgField(complexArg: $complexVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -382,7 +382,7 @@ fn complexinput_to_complexinput_in_field_position() {
             complexArgField(complexArg: { requiredArg: $boolVar })
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -400,7 +400,7 @@ fn boolean_nonnull_to_boolean_nonnull_in_directive() {
         {
           dog @include(if: $boolVar)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -418,7 +418,7 @@ fn int_to_int_nonnull() {
             nonNullIntArgField(nonNullIntArg: $intArg)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -444,7 +444,7 @@ fn int_to_int_nonnull_within_fragment() {
             ...nonNullIntArgFieldFrag
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -473,7 +473,7 @@ fn int_to_int_nonnull_within_nested_fragment() {
             ...outerFrag
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -496,7 +496,7 @@ fn string_over_boolean() {
             booleanArgField(booleanArg: $stringVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -521,7 +521,7 @@ fn string_over_string_list() {
             stringListArgField(stringListArg: $stringVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -544,7 +544,7 @@ fn boolean_to_boolean_nonnull_in_directive() {
         "query Query($boolVar: Boolean) {
           dog @include(if: $boolVar)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -567,7 +567,7 @@ fn string_to_boolean_nonnull_in_directive() {
         "query Query($stringVar: String) {
           dog @include(if: $stringVar)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -593,7 +593,7 @@ fn string_list_to_string_nonnull_list() {
             stringListNonNullArgField(stringListNonNullArg: $stringListVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -615,7 +615,7 @@ fn int_to_int_non_null_with_null_default_value() {
             nonNullIntArgField(nonNullIntArg: $intVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -638,7 +638,7 @@ fn int_to_int_non_null_with_default_value() {
             nonNullIntArgField(nonNullIntArg: $intVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -657,7 +657,7 @@ fn int_to_int_non_null_where_argument_with_default_value() {
             nonNullFieldWithDefault(nonNullIntArg: $intVar)
           }
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 
@@ -674,7 +674,7 @@ fn boolean_to_boolean_non_null_with_default_value() {
         "query Query($boolVar: Boolean = false) {
           dog @include(if: $boolVar)
         }",
-        &TEST_SCHEMA,
+        TEST_SCHEMA,
         &mut plan,
     );
 

--- a/src/validation/test_utils.rs
+++ b/src/validation/test_utils.rs
@@ -233,13 +233,11 @@ pub fn create_plan_from_rule(rule: Box<dyn ValidationRule>) -> ValidationPlan {
     let mut rules = Vec::new();
     rules.push(rule);
 
-    
-
     ValidationPlan { rules }
 }
 
 #[cfg(test)]
-pub fn get_messages(validation_errors: &Vec<ValidationError>) -> Vec<&String> {
+pub fn get_messages(validation_errors: &[ValidationError]) -> Vec<&String> {
     validation_errors
         .iter()
         .map(|m| &m.message)

--- a/src/validation/test_utils.rs
+++ b/src/validation/test_utils.rs
@@ -233,9 +233,9 @@ pub fn create_plan_from_rule(rule: Box<dyn ValidationRule>) -> ValidationPlan {
     let mut rules = Vec::new();
     rules.push(rule);
 
-    let plan = ValidationPlan { rules };
+    
 
-    plan
+    ValidationPlan { rules }
 }
 
 #[cfg(test)]
@@ -264,7 +264,7 @@ type Query {
         .unwrap()
         .into_static();
 
-    validate(&schema_ast, &operation_ast, &plan)
+    validate(&schema_ast, &operation_ast, plan)
 }
 
 #[cfg(test)]
@@ -279,11 +279,11 @@ pub fn test_operation_with_schema<'a>(
     plan: &'a ValidationPlan,
 ) -> Vec<ValidationError> {
     let schema_clone = string_to_static_str(schema.to_string() + INTROSPECTION_SCHEMA);
-    let schema_ast = graphql_parser::parse_schema(&schema_clone).expect("Failed to parse schema");
+    let schema_ast = graphql_parser::parse_schema(schema_clone).expect("Failed to parse schema");
 
     let operation_ast = graphql_parser::parse_query(operation)
         .unwrap()
         .into_static();
 
-    validate(&schema_ast, &operation_ast, &plan)
+    validate(&schema_ast, &operation_ast, plan)
 }

--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -1,4 +1,4 @@
-use graphql_parser::Pos;
+use crate::parser::Pos;
 use serde::ser::*;
 use serde::{Serialize, Serializer};
 use serde_with::{serde_as, SerializeAs};

--- a/src/validation/utils.rs
+++ b/src/validation/utils.rs
@@ -4,7 +4,7 @@ use serde::{Serialize, Serializer};
 use serde_with::{serde_as, SerializeAs};
 use std::fmt::Debug;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ValidationErrorContext {
     pub errors: Vec<ValidationError>,
 }

--- a/src/validation/validate.rs
+++ b/src/validation/validate.rs
@@ -26,6 +26,12 @@ impl ValidationPlan {
     }
 }
 
+impl Default for ValidationPlan {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub fn validate<'a>(
     schema: &'a schema::Document,
     operation: &'a query::Document,


### PR DESCRIPTION
Feature-based dependency to switch between https://github.com/graphql-hive/graphql-parser-hive-fork and https://github.com/graphql-rust/graphql-parser 

Also, cleaned up the code a bit and applied some Clippy fixes. 